### PR TITLE
Updated HA Gateway Parameters, ignore ReadMe in Pull Request

### DIFF
--- a/rds-deployment-ha-gateway/README.md
+++ b/rds-deployment-ha-gateway/README.md
@@ -37,9 +37,9 @@ This template expects the same names of resources from RDS deployment, if resour
 
 Click the button below to deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FRDS-Templates%2Fmaster%2Frds-deployment-ha-gateway%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FChristianMontoya%2FRDS-Templates%2Fmaster%2Frds-deployment-ha-gateway%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Frds-deployment-HA%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FChristianMontoya%2Fazure-quickstart-templates%2Fmaster%2Frds-deployment-HA%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>

--- a/rds-deployment-ha-gateway/azuredeploy.json
+++ b/rds-deployment-ha-gateway/azuredeploy.json
@@ -2,25 +2,12 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "dnsLabelPrefix": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique public DNS prefix for the deployment. The fqdn will look something like '<dnsname>.westus.cloudapp.azure.com'. Up to 62 chars, digits or dashes, lowercase, should start with a letter: must conform to '^[a-z][a-z0-9-]{1,61}[a-z0-9]$'."
-      }
-    },
     "gatewayLoadBalancer": {
       "type": "string",
       "metadata": {
         "description": "The gateway Load balancer name must match from the RDS deployment. And default value taken by template is loadbalancer."
       },
       "defaultValue": "loadBalancer"
-    },
-    "gatewayPublicIp": {
-      "type": "string",
-      "metadata": {
-        "description": "The gateway public ip name must match from the RDS deployment. And default value taken by template is gwpip."
-      },
-      "defaultValue": "gwpip"
     },
     "backendAddressPools": {
       "type": "string",
@@ -54,7 +41,7 @@
         "description": "The password for the administrator account of the new VM and the domain"
       }
     },
-    "numberOfWebGwInstances": {
+    "numberOfNewWebGwInstances": {
       "type": "int",
       "defaultValue": 2,
       "metadata": {
@@ -67,7 +54,7 @@
         "description": "FQDN for Broker Server"
       }
     },
-    "WebURL": {
+    "publicIPAddressDNSName": {
       "type": "string",
       "metadata": {
         "description": "This is RD Gateway external FQDN. This shall be picked from existing basic RDS deploment."
@@ -121,13 +108,9 @@
   "variables": {
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
-    "vnetAddressRange": "10.0.0.0/16",
-    "subnetAddressRange": "10.0.0.0/24",
-    "dnsServerPrivateIp": "10.0.0.8",
     "subnet-id": "[concat(resourceId('Microsoft.Network/virtualNetworks',parameters('existingVnet')),'/subnets/',parameters('existingSubnet'))]",
     "assetLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/rds-deployment",
     "apiVersion": "2015-06-15",
-    "PublicIPLocation": "[concat(parameters('dnsLabelPrefix'),'.','[resourceGroup().location]','.cloudapp.azure.com')]"
   },
   "resources": [
     {
@@ -146,25 +129,13 @@
       "location": "[resourceGroup().location]"
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[parameters('gatewayPublicIp')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic",
-        "dnsSettings": {
-          "domainNameLabel": "[parameters('dnsLabelPrefix')]"
-        }
-      }
-    },
-    {
       "name": "[concat('gw-',copyindex(),'-nic')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
       "apiVersion": "[variables('apiversion')]",
       "copy": {
         "name": "gw-nic-loop",
-        "count": "[parameters('numberOfWebGwInstances')]"
+        "count": "[parameters('numberOfNewWebGwInstances')]"
       },
       "properties": {
         "ipConfigurations": [
@@ -192,7 +163,7 @@
       "apiVersion": "[variables('apiversion')]",
       "copy": {
         "name": "gw-vm-loop",
-        "count": "[parameters('numberOfWebGwInstances')]"
+        "count": "[parameters('numberOfNewWebGwInstances')]"
       },
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
@@ -287,7 +258,7 @@
             "protectedSettings": {
               "Items": { "AdminPassword": "[parameters('adminPassword')]" },
               "storageAccountName": "[parameters('storageaccountname')]",
-              "commandToExecute": "[Concat('powershell.exe -ExecutionPolicy Unrestricted -File', ' ', 'WebAndGwFarmAdd_PostConfig1.1.ps1',' ','-username \"',parameters('adminusername'),'\" ', '-password \"',parameters('adminpassword'),'\" ','-BrokerServer \"',parameters('BrokerServer'),'\" ','-WebURL \"',parameters('WebURL'),'\" ','-Domainname \"',parameters('adDomainName'),'\" ','-DomainNetbios \"',parameters('DomainNetbios'),'\" ','-numberofwebServers ',parameters('numberOfWebGwInstances'))]"
+              "commandToExecute": "[Concat('powershell.exe -ExecutionPolicy Unrestricted -File', ' ', 'WebAndGwFarmAdd_PostConfig1.1.ps1',' ','-username \"',parameters('adminusername'),'\" ', '-password \"',parameters('adminpassword'),'\" ','-BrokerServer \"',parameters('BrokerServer'),'\" ','-WebURL \"',parameters('publicIPAddressDNSName'),'\" ','-Domainname \"',parameters('adDomainName'),'\" ','-DomainNetbios \"',parameters('DomainNetbios'),'\" ','-numberofwebServers ',parameters('numberOfNewWebGwInstances'))]"
             }
           }
         }

--- a/rds-deployment-ha-gateway/azuredeploy.parameters.json
+++ b/rds-deployment-ha-gateway/azuredeploy.parameters.json
@@ -11,20 +11,17 @@
     "adDomainName": {
       "value": "mydomain.local"
     },
-    "numberOfWebGwInstances": {
+    "numberOfNewWebGwInstances": {
       "value": 2
     },
     "brokerServer": {
       "value": "Broker.Mydomain.local"
     },
-    "WebURL": {
+    "publicIPAddressDSName": {
       "value": "RDS-WebURL"
     },
     "domainNetbios": {
       "value": "Mydomain"
-    },
-    "dnsLabelPrefix": {
-      "value": "GEN-UNIQUE"
     },
     "storageAccountName": {
       "value": "GEN-UNIQUE"
@@ -32,7 +29,7 @@
     "gw-availabilityset": {
       "value": "gw-availabilityset"
     },
-    "loadBalancer": {
+    "gatewayLoadBalancer": {
       "value": "loadBalancer"
     },
     "backendAddressPools": {
@@ -43,6 +40,12 @@
     },
     "existingSubnet": {
       "value": "Subnet"
+    },
+    "imageSKU": {
+      "value": "2016-Datacenter"
+    },
+    "vmSize": {
+      "value": "Standard_A2"
     }
   }
 }

--- a/rds-deployment-uber/azuredeploy.json
+++ b/rds-deployment-uber/azuredeploy.json
@@ -242,14 +242,8 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "dnsLabelPrefix": {
-            "value": "[variables('gwdnsLabelPrefix')]"
-          },
           "gatewayLoadBalancer": {
             "value": "[variables('loadBalancer')]"
-          },
-          "gatewayPublicIp": {
-            "value": "[variables('gatewaypublicIp')]"
           },
           "backendAddressPools": {
             "value": "[variables('backEndAddressPool')]"
@@ -266,13 +260,13 @@
           "adminPassword": {
             "value": "[parameters('adminPassword')]"
           },
-          "numberOfWebGwInstances": {
+          "numberOfNewWebGwInstances": {
             "value": "[parameters('numberOfWebGwInstances')]"
           },
           "brokerServer": {
             "value": "[variables('rdBrokerServer')]"
           },
-          "WebURL": {
+          "publicIPAddressDNSName": {
             "value": "[variables('rdGatewayWebURL')]"
           },
           "domainNetbios": {


### PR DESCRIPTION
Updated HA Gateway script and took out unnecessary parameters and variables. Tested and deployed just fine! One question:
- We expect customers to run the "UpdateCertificate" template after this, yes? I wasn't able to failover from the original Gateway to the newly created Gateway since the new one didn't have the cert installed.