### PR TITLE
Pmarques/deploy agent zip update

### DIFF
--- a/wvd-templates/Create and provision WVD host pool/mainTemplate.json
+++ b/wvd-templates/Create and provision WVD host pool/mainTemplate.json
@@ -339,7 +339,7 @@
             "location": "[resourceGroup().location]",
             "dependsOn": [
                 "vmCreation-linkedTemplate",
-                "rdsh-dsc-loop"
+                "[concat('Microsoft.Compute/virtualMachines/', concat(variables('rdshPrefix'), copyindex(),'/extensions/dscextension'))]"
             ],
             "copy": {
                 "name": "rdsh-domain-join-loop",


### PR DESCRIPTION
Updated DeployAgent.zip package with a change to the DeployAgent.ps1 file that was failing to delete a file and we removed since no other cleanup process is taking place.
Also, made domain join process to depend individually on DSC execution for Windows Servers.