### PR TITLE
Fix to the registration issues when more than 2 or 3 VMs are deployed

### DIFF
--- a/wvd-templates/Create and provision WVD host pool/DSC/Script.ps1
+++ b/wvd-templates/Create and provision WVD host pool/DSC/Script.ps1
@@ -48,8 +48,8 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$EnablePersistentDesktop="False",
 
-    [Parameter(Mandatory = $true)]
-    [string]$DefaultDesktopUsers
+    [Parameter(Mandatory = $false)]
+    [string]$DefaultDesktopUsers=""
 )
 
 function Write-Log
@@ -359,19 +359,20 @@ else
     {
         Write-Log -Message "Hostpool UseReverseConnect already enabled as true"
     }
-    
-    # Creating registration token
-    $Registered = Export-RdsRegistrationInfo -TenantName $TenantName -HostPoolName $HostPoolName -ErrorAction SilentlyContinue
+
+    # Random wait time to create or export registration info
+    Start-Sleep (5..15 | Get-Random)
+    $Registered = New-RdsRegistrationInfo -TenantName $TenantName -HostPoolName $HostPoolName -ExpirationHours $Hours -ErrorAction SilentlyContinue
     if (!$Registered)
     {
-        $Registered = New-RdsRegistrationInfo -TenantName $TenantName -HostPoolName $HostPoolName -ExpirationHours $Hours
+        $Registered = Export-RdsRegistrationInfo -TenantName $TenantName -HostPoolName $HostPoolName 
         $obj =  $Registered | Out-String
-        Write-Log -Message "Created new Rds RegistrationInfo into variable 'Registered': $obj"
+        Write-Log -Message "Exported Rds RegistrationInfo into variable 'Registered': $obj"
     }
     else
     {
         $obj =  $Registered | Out-String
-        Write-Log -Message "Exported Rds RegistrationInfo into variable 'Registered': $obj"
+        Write-Log -Message "Created new Rds RegistrationInfo into variable 'Registered': $obj"
     }
 
     # Executing DeployAgent psl file in rdsh vm and add to hostpool


### PR DESCRIPTION
PR to fix issues when multiple VMs are deployed at the same time. The way this is now, as we create higher number of VMs, the likelihood of this issue happening increases significantly since lets say that a few VMs identify at the same time that there is no registration info, if multiple VMs does that at the same time the error described below will come up because more than one will execute the New-RdsRegistrationInfo.

Error that shows up:

RegistrationInfo exists for HostPoolName '<pool name>'. Use Export-RdsRegistrationInfo