### PR TITLE
Adding VM names in output

### DIFF
--- a/wvd-templates/Create and provision WVD host pool/mainTemplate.json
+++ b/wvd-templates/Create and provision WVD host pool/mainTemplate.json
@@ -233,10 +233,22 @@
         "hostPoolDescription": "Created through ARM template",
         "registrationExpirationHours": "48",
         "vmTemplateName": "[concat( if(variables('rdshManagedDisks'), 'managedDisks', 'unmanagedDisks'), '-', toLower(replace(parameters('rdshImageSource'),' ', '')), 'vm')]",
-        "vmTemplateUri": "[concat(parameters('_artifactsLocation'),'/nestedtemplates/',variables('vmTemplateName'),'.json', parameters('_artifactsLocationSasToken'))]"
+        "vmTemplateUri": "[concat(parameters('_artifactsLocation'),'/nestedtemplates/',variables('vmTemplateName'),'.json', parameters('_artifactsLocationSasToken'))]",
+        "rdshVmNamesOutput": {
+            "copy":[
+                {
+                    "name":"rdshVmNamesCopy",
+                    "count":"[parameters('rdshNumberOfInstances')]",
+                    "input": {
+                        "name":"[concat(variables('rdshPrefix'),copyIndex('rdshVmNamesCopy'))]"
+                    }
+                }
+            ]
+        }
     },
     "resources": [
         {
+            "condition":false,
             "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/availabilitySets",
             "name": "[concat(variables('rdshPrefix'), 'availabilitySet')]",
@@ -250,6 +262,7 @@
             }
         },
         {
+            "condition":false,
             "apiVersion": "2017-05-10",
             "name": "vmCreation-linkedTemplate",
             "type": "Microsoft.Resources/deployments",
@@ -309,6 +322,7 @@
             ]
         },
         {
+            "condition":false,
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), copyindex(),'/', 'joindomain')]",
@@ -338,6 +352,7 @@
             }
         },
         {
+            "condition":false,
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), '0/', 'dscextension')]",
@@ -384,7 +399,7 @@
             }
         },
         {
-            "condition":"[greater(parameters('rdshNumberOfInstances'),1)]",
+            "condition":false,
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), copyindex(1),'/', 'dscextension')]",
@@ -429,5 +444,11 @@
                 }
             }
         }
-    ]
+    ],
+    "outputs": {
+        "rdshVmNamesObject":{
+            "value":"[variables('rdshVmNamesOutput')]",
+            "type": "object"
+        }
+    }
 }

--- a/wvd-templates/Create and provision WVD host pool/mainTemplate.json
+++ b/wvd-templates/Create and provision WVD host pool/mainTemplate.json
@@ -248,7 +248,6 @@
     },
     "resources": [
         {
-            "condition":false,
             "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/availabilitySets",
             "name": "[concat(variables('rdshPrefix'), 'availabilitySet')]",
@@ -262,7 +261,6 @@
             }
         },
         {
-            "condition":false,
             "apiVersion": "2017-05-10",
             "name": "vmCreation-linkedTemplate",
             "type": "Microsoft.Resources/deployments",
@@ -322,7 +320,6 @@
             ]
         },
         {
-            "condition":false,
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), copyindex(),'/', 'joindomain')]",
@@ -352,7 +349,6 @@
             }
         },
         {
-            "condition":false,
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), '0/', 'dscextension')]",
@@ -399,7 +395,7 @@
             }
         },
         {
-            "condition":false,
+            "condition":"[greater(parameters('rdshNumberOfInstances'),1)]",
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(variables('rdshPrefix'), copyindex(1),'/', 'dscextension')]",


### PR DESCRIPTION
Created new variable that generates an array with the VM Names and outputs it after deployment is completed. This is very minor change to be used by customers if they want to consume these VM names into for example an Azure Pipeline task and perform some operations post deployment.