### PR TITLE
DefaultDesktop Users added - partially fixes Azure/RDS-Templates#191

### DIFF
--- a/wvd-templates/Update existing WVD host pool/mainTemplate.json
+++ b/wvd-templates/Update existing WVD host pool/mainTemplate.json
@@ -52,6 +52,13 @@
                 "description": "Message that will be displayed to the user notifying them of the automatic logoff."
             }
         },
+        "defaultDesktopUsers": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide a comma separated list of users you would like to add to access the desktop for this host pool. Example: user1@contoso.com,user2@contoso.com,user3@contoso.com "
+            },
+            "defaultValue": ""
+        },
         "tenantAdminUpnOrApplicationId": {
             "type": "string",
             "metadata": {
@@ -409,7 +416,8 @@
                         "deleteordeallocateVMs": "[parameters('ActionOnPreviousVirtualMachines')]",
                         "messageTitle": "[variables('messageTitle')]",
                         "userNotificationMessege": "[parameters('userNotificationMessege')]",
-                        "userLogoffDelayInMinutes": "[parameters('userLogoffDelayInMinutes')]"
+                        "userLogoffDelayInMinutes": "[parameters('userLogoffDelayInMinutes')]",
+                        "DefaultDesktopUsers": "[concat('\"',parameters('defaultDesktopUsers'),'\"')]"
                     }
                 },
                 "ProtectedSettings": {


### PR DESCRIPTION
This is a first fix for what I am assuming will be a series needed to get the template for updating an existing WVD pool.

The issues appear to be caused by an update to DSC/Configuration.zip that are not matched by required updated in the main template.

This template update resolves the first error that you receive on trying to deploy the template as detailed in bug Azure/RDS-Templates#191 . With this in place the template still errors, but I'm working on the next one now and wanted to save anyone having the same problems from dealing with at least this stage.