### PR TITLE
Correct Function Set-ScriptVariable Name

### DIFF
--- a/wvd-sh/WVD scaling script/basicScale.ps1
+++ b/wvd-sh/WVD scaling script/basicScale.ps1
@@ -106,7 +106,7 @@ function Write-UsageLog {
 .SYNOPSIS
 Function for creating a variable from JSON
 #>
-function SetScriptVariable ($Name,$Value) {
+function Set-ScriptVariable ($Name,$Value) {
   Invoke-Expression ("`$Script:" + $Name + " = `"" + $Value + "`"")
 }
 


### PR DESCRIPTION
The function was called SetScriptVariable but is used later in the script as Set-ScriptVariable. Have updated the function name.