### PR TITLE
Bug Fix: prefix the vmCreation-linkedTemplate with rdshNamePrefix in Update existing WVD host pool template

### DIFF
--- a/wvd-templates/Update existing WVD host pool/mainTemplate.json
+++ b/wvd-templates/Update existing WVD host pool/mainTemplate.json
@@ -279,7 +279,8 @@
                     }
                 }
             ]
-        }
+        },
+        "vmCreation-linkedTemplate_name": "[concat(variables('rdshPrefix'), 'vmCreation-linkedTemplate')]"
     },
     "resources": [
         {
@@ -297,7 +298,7 @@
         },
         {
             "type": "Microsoft.Resources/deployments",
-            "name": "vmCreation-linkedTemplate",
+            "name": "[variables('vmCreation-linkedTemplate_name')]",
             "apiVersion": "2018-05-01",
             "properties": {
                 "mode": "Incremental",
@@ -360,7 +361,7 @@
             "name": "[concat(variables('rdshPrefix'), copyindex(),'/', 'joindomain')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "vmCreation-linkedTemplate"
+                "[variables('vmCreation-linkedTemplate_name')]"
             ],
             "copy": {
                 "name": "rdsh-domain-join-loop",


### PR DESCRIPTION
prefix the vmCreation-linkedTemplate with rdshNamePrefix to support multiple vm deployment creation at the same time within the same resrc group in Update existing WVD host pool template