### PR TITLE
Update the VM Gallery Image used for Windows 10 Enterprise 1903 to not be the "N" variant

### DIFF
--- a/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -133,7 +133,7 @@
             "Windows-10-Enterprise-1903": {
                 "galleryPublisher": "MicrosoftWindowsDesktop",
                 "galleryOffer": "Windows-10",
-                "gallerySku": "19h1-entn"
+                "gallerySku": "19h1-ent"
             },
             "2016-Datacenter": {
                 "galleryPublisher": "MicrosoftwindowsServer",


### PR DESCRIPTION
This change is needed because WVD doesn't support the "N" variant of Windows 10.