### PR TITLE
Add Windows 1909 SKUs to the list of gallery images.

### DIFF
--- a/wvd-templates/Create and provision WVD host pool/createUiDefinition.json
+++ b/wvd-templates/Create and provision WVD host pool/createUiDefinition.json
@@ -396,15 +396,15 @@
 							"allowedValues": [
 								{
 									"label": "Windows 10 Enterprise multi-session with Office 365 ProPlus",
-									"value": "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus"
+									"value": "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1909"
 								},
 								{
 									"label": "Windows 10 Enterprise multi-session",
-									"value": "Windows-10-Enterprise-multi-session"
+									"value": "Windows-10-Enterprise-multi-session-1909"
 								},
 								{
-									"label": "Windows 10 Enterprise, Version 1903",
-									"value": "Windows-10-Enterprise-1903"
+									"label": "Windows 10 Enterprise",
+									"value": "Windows-10-Enterprise-1909"
 								},
 								{
 									"label": "Windows Server 2016 Datacenter",

--- a/wvd-templates/Create and provision WVD host pool/mainTemplate.json
+++ b/wvd-templates/Create and provision WVD host pool/mainTemplate.json
@@ -38,11 +38,17 @@
         "rdshGalleryImageSKU": {
             "type": "string",
             "metadata": {
-                "description": "(Required when rdshImageSource = Gallery) Gallery image SKU."
+                "description": "(Required when rdshImageSource = Gallery) Gallery image SKU. Values without a numeric suffix, such as 1903, will use the latest release available in this template."
             },
             "allowedValues": [
-                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus",
+               "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1909",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1903",
                 "Windows-10-Enterprise-multi-session",
+                "Windows-10-Enterprise-multi-session-1909",
+                "Windows-10-Enterprise-multi-session-1903",
+                "Windows-10-Enterprise-Latest",
+                "Windows-10-Enterprise-1909",
                 "Windows-10-Enterprise-1903",
                 "2016-Datacenter"
             ],

--- a/wvd-templates/Update existing WVD host pool/mainTemplate.json
+++ b/wvd-templates/Update existing WVD host pool/mainTemplate.json
@@ -38,11 +38,17 @@
         "rdshGalleryImageSKU": {
             "type": "string",
             "metadata": {
-                "description": "(Required when rdshImageSource = Gallery) Gallery image SKU."
+                "description": "(Required when rdshImageSource = Gallery) Gallery image SKU. Values without a numeric suffix, such as 1903, will use the latest release available in this template."
             },
             "allowedValues": [
                 "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1909",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1903",
                 "Windows-10-Enterprise-multi-session",
+                "Windows-10-Enterprise-multi-session-1909",
+                "Windows-10-Enterprise-multi-session-1903",
+                "Windows-10-Enterprise-Latest",
+                "Windows-10-Enterprise-1909",
                 "Windows-10-Enterprise-1903",
                 "2016-Datacenter"
             ],

--- a/wvd-templates/Update existing WVD host pool/mainTemplate.json
+++ b/wvd-templates/Update existing WVD host pool/mainTemplate.json
@@ -52,7 +52,7 @@
                 "Windows-10-Enterprise-1903",
                 "2016-Datacenter"
             ],
-            "defaultValue": "Windows-10-Enterprise-multi-session"
+            "defaultValue": "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus"
         },
         "rdshCustomImageSourceName": {
             "type": "string",

--- a/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -18,7 +18,13 @@
             "type": "string",
             "allowedValues": [
                 "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1909",
+                "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1903",
                 "Windows-10-Enterprise-multi-session",
+                "Windows-10-Enterprise-multi-session-1909",
+                "Windows-10-Enterprise-multi-session-1903",
+                "Windows-10-Enterprise-Latest",
+                "Windows-10-Enterprise-1909",
                 "Windows-10-Enterprise-1903",
                 "2016-Datacenter"
             ],
@@ -123,12 +129,42 @@
             "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus": {
                 "galleryPublisher": "MicrosoftWindowsDesktop",
                 "galleryOffer": "office-365",
+                "gallerySku": "19h2-evd-o365pp"
+            },
+             "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1909": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "office-365",
+                "gallerySku": "19h2-evd-o365pp"
+            },
+             "Windows-10-Enterprise-multi-session-with-Office-365-ProPlus-1903": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "office-365",
                 "gallerySku": "1903-evd-o365pp"
             },
             "Windows-10-Enterprise-multi-session": {
                 "galleryPublisher": "MicrosoftWindowsDesktop",
                 "galleryOffer": "Windows-10",
+                "gallerySku": "19h2-evd"
+            },
+            "Windows-10-Enterprise-multi-session-1909": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "Windows-10",
+                "gallerySku": "19h2-evd"
+            },
+            "Windows-10-Enterprise-multi-session-1903": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "Windows-10",
                 "gallerySku": "19h1-evd"
+            },
+            "Windows-10-Enterprise-Latest": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "Windows-10",
+                "gallerySku": "19h2-ent"
+            },
+            "Windows-10-Enterprise-1909": {
+                "galleryPublisher": "MicrosoftWindowsDesktop",
+                "galleryOffer": "Windows-10",
+                "gallerySku": "19h2-ent"
             },
             "Windows-10-Enterprise-1903": {
                 "galleryPublisher": "MicrosoftWindowsDesktop",


### PR DESCRIPTION
This also changes the rdshGalleryImageSKU values Windows-10-Enterprise-multi-session and Windows-10-Enterprise-multi-session-with-Office-365-ProPlus to use Windows 1909 instead of 1903.