### PR TITLE
Add back `enablePersistentDesktop` param in nested templates for backwards compatibility 

### DIFF
--- a/wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -110,13 +110,20 @@
                 "description": "Set this parameter to true if an Availability set was created. Defaults to true. Using an Availability set limits you to a maximum of 200 virtual machines For more info: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#virtual-machines-limits---azure-resource-manager."
             },
             "defaultValue": true
+        },
+        "enablePersistentDesktop": {
+            "type": "bool",
+            "metadata": {
+                "description": "Set this parameter to true if you would like to enable Persistent Desktop experience. Defaults to false. Note: Do not use this, it is here for backwards compatibility and may be removed soon."
+            },
+            "defaultValue": false
         }
     },
     "variables": {
         "imageResourceId": "[resourceId(parameters('rdshImageSourceResourceGroup'), 'Microsoft.Compute/images', parameters('rdshImageSourceName'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "availabilitySetId": {
-            "id": "[if(parameters('createAvailabilitySet'), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
+            "id": "[if(and(parameters('createAvailabilitySet'), not(parameters('enablePersistentDesktop'))), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
         }
     },
     "resources": [
@@ -160,7 +167,7 @@
                 "hardwareProfile": {
                     "vmSize": "[parameters('rdshVmSize')]"
                 },
-                "availabilitySet": "[if(parameters('createAvailabilitySet'), variables('availabilitySetId'), json('null'))]",
+                "availabilitySet": "[if(not(equals(variables('availabilitySetId').id, json('null'))), variables('availabilitySetId'), json('null'))]",
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), copyindex())]",
                     "adminUsername": "[parameters('existingDomainUsername')]",

--- a/wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -110,13 +110,20 @@
                 "description": "Set this parameter to true if an Availability set was created. Defaults to true. Using an Availability set limits you to a maximum of 200 virtual machines For more info: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#virtual-machines-limits---azure-resource-manager."
             },
             "defaultValue": true
+        },
+        "enablePersistentDesktop": {
+            "type": "bool",
+            "metadata": {
+                "description": "Set this parameter to true if you would like to enable Persistent Desktop experience. Defaults to false. Note: Do not use this, it is here for backwards compatibility and may be removed soon."
+            },
+            "defaultValue": false
         }
     },
     "variables": {
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "imageName": "[concat(parameters('rdshPrefix'), 'image')]",
         "availabilitySetId": {
-            "id": "[if(parameters('createAvailabilitySet'), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
+            "id": "[if(and(parameters('createAvailabilitySet'), not(parameters('enablePersistentDesktop'))), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
         }
     },
     "resources": [
@@ -177,7 +184,7 @@
                 "hardwareProfile": {
                     "vmSize": "[parameters('rdshVmSize')]"
                 },
-                "availabilitySet": "[if(parameters('createAvailabilitySet'), variables('availabilitySetId'), json('null'))]",
+                "availabilitySet": "[if(not(equals(variables('availabilitySetId').id, json('null'))), variables('availabilitySetId'), json('null'))]",
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), copyindex())]",
                     "adminUsername": "[parameters('existingDomainUsername')]",

--- a/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -122,6 +122,13 @@
                 "description": "Set this parameter to true if an Availability set was created. Defaults to true. Using an Availability set limits you to a maximum of 200 virtual machines For more info: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#virtual-machines-limits---azure-resource-manager."
             },
             "defaultValue": true
+        },
+        "enablePersistentDesktop": {
+            "type": "bool",
+            "metadata": {
+                "description": "Set this parameter to true if you would like to enable Persistent Desktop experience. Defaults to false. Note: Do not use this, it is here for backwards compatibility and may be removed soon."
+            },
+            "defaultValue": false
         }
     },
     "variables": {
@@ -179,7 +186,7 @@
         },
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "availabilitySetId": {
-            "id": "[if(parameters('createAvailabilitySet'), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
+            "id": "[if(and(parameters('createAvailabilitySet'), not(parameters('enablePersistentDesktop'))), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
         }
     },
     "resources": [
@@ -223,7 +230,7 @@
                 "hardwareProfile": {
                     "vmSize": "[parameters('rdshVmSize')]"
                 },
-                "availabilitySet": "[if(parameters('createAvailabilitySet'), variables('availabilitySetId'), json('null'))]",
+                "availabilitySet": "[if(not(equals(variables('availabilitySetId').id, json('null'))), variables('availabilitySetId'), json('null'))]",
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), copyindex())]",
                     "adminUsername": "[parameters('existingDomainUsername')]",

--- a/wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -110,13 +110,20 @@
                 "description": "Set this parameter to true if an Availability set was created. Defaults to true. Using an Availability set limits you to a maximum of 200 virtual machines For more info: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#virtual-machines-limits---azure-resource-manager."
             },
             "defaultValue": true
+        },
+        "enablePersistentDesktop": {
+            "type": "bool",
+            "metadata": {
+                "description": "Set this parameter to true if you would like to enable Persistent Desktop experience. Defaults to false. Note: Do not use this, it is here for backwards compatibility and may be removed soon."
+            },
+            "defaultValue": false
         }
     },
     "variables": {
         "storageAccountName": "[split( split( parameters('VmImageVhdUri'), '/')[2], '.' )[0]]",
         "storageaccount": "[concat(resourceId(parameters('storageAccountResourceGroupName'),'Microsoft.Storage/storageAccounts',variables('storageAccountName')))]",
         "availabilitySetId": {
-            "id": "[if(parameters('createAvailabilitySet'), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
+            "id": "[if(and(parameters('createAvailabilitySet'), not(parameters('enablePersistentDesktop'))), resourceId('Microsoft.Compute/availabilitySets/', concat(parameters('rdshPrefix'), 'availabilitySet')), json('null'))]"
         }
     },
     "resources": [
@@ -160,7 +167,7 @@
                 "hardwareProfile": {
                     "vmSize": "[parameters('rdshVmSize')]"
                 },
-                "availabilitySet": "[if(parameters('createAvailabilitySet'), variables('availabilitySetId'), json('null'))]",
+                "availabilitySet": "[if(not(equals(variables('availabilitySetId').id, json('null'))), variables('availabilitySetId'), json('null'))]",
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), copyindex())]",
                     "adminUsername": "[parameters('existingDomainUsername')]",


### PR DESCRIPTION
Add back `enablePersistentDesktop` param in nested templates for backwards compatibility in case nested templates are called from older versions of mainTemplate.json. Also addressing issue #425 