### PR TITLE
Update updateWvdMgmtUxApiUrl.ps1

### DIFF
--- a/wvd-templates/wvd-management-ux/deploy/scripts/updateWvdMgmtUxApiUrl.ps1
+++ b/wvd-templates/wvd-management-ux/deploy/scripts/updateWvdMgmtUxApiUrl.ps1
@@ -71,7 +71,7 @@ $Subscription = Select-AzSubscription -SubscriptionId $SubscriptionId
 Set-AzContext -SubscriptionObject $Subscription.ExtendedProperties
 
 # Get the Role Assignment of the authenticated user
-$RoleAssignment = Get-AzRoleAssignment -SignInName $context.Account
+$RoleAssignment = Get-AzRoleAssignment -SignInName $context.Account -ExpandPrincipalGroups
 
 # Validate whether the authenticated user having the Owner or Contributor role
 if ($RoleAssignment.RoleDefinitionName -eq "Owner" -or $RoleAssignment.RoleDefinitionName -eq "Contributor")


### PR DESCRIPTION
Changed updateWvdMgmtUxApirul.ps1 by adding -ExpandPrincipalGroups to line 74 so that Get-AzRoleAssignment access via a group rather than explicit assignment. Without this flag, the user may have access assigned via a group but the command will not return that access and the script outputs the error: "Authenticated user should have the Owner/Contributor permissions"