### PR TITLE
off peak hours - drain node changes

### DIFF
--- a/wvd-templates/wvd-scaling-script/basicScale.ps1
+++ b/wvd-templates/wvd-scaling-script/basicScale.ps1
@@ -1276,13 +1276,7 @@ else {
 					if ($NumberOfRunningHost -gt $MinimumNumberOfRDSH) {
 						$SessionHostName = $SessionHost.SessionHostName
 						$VMName = $SessionHostName.Split(".")[0]
-						if ($SessionHost.Sessions -eq 0) {
-							# Shutdown the Azure VM, which session host have 0 sessions
-							Write-Output "Stopping Azure VM: $VMName and waiting for it to complete ..."
-							Stop-SessionHost -VMName $VMName
-						}
-						else {
-							# Ensure the running Azure VM is set as drain mode
+						# Ensure the running Azure VM is set as drain mode
 							try {
 								$CheckMinimumDrianMode = (Get-RdsSessionHost -TenantName $TenantName -HostPoolName $HostpoolName | Where-Object { $_.AllowNewSession -eq "True" -and $AllSessionHosts -contains $_ }).Count
 								if ($CheckMinimumDrianMode -gt $MinimumNumberOfRDSH) {
@@ -1293,6 +1287,13 @@ else {
 								Write-Output "Unable to set it to allow connections on session host: $SessionHostName with error: $($_.exception.message)"
 								exit
 							}
+						if ($SessionHost.Sessions -eq 0) {
+							# Shutdown the Azure VM, which session host have 0 sessions
+							Write-Output "Stopping Azure VM: $VMName and waiting for it to complete ..."
+							Stop-SessionHost -VMName $VMName
+						}
+						else {
+							
 							if ($LimitSecondsToForceLogOffUser -eq 0) {
 								continue
 							}

--- a/wvd-templates/wvd-scaling-script/basicScale.ps1
+++ b/wvd-templates/wvd-scaling-script/basicScale.ps1
@@ -614,16 +614,7 @@ if ($LogAnalyticsWorkspaceId -and $LogAnalyticsPrimaryKey)
 					if ($NumberOfRunningHost -gt $MinimumNumberOfRDSH) {
 						$SessionHostName = $SessionHost.SessionHostName
 						$VMName = $SessionHostName.Split(".")[0]
-						if ($SessionHost.Sessions -eq 0) {
-							# Shutdown the Azure VM, which session host have 0 sessions
-							Write-Output "Stopping Azure VM: $VMName and waiting for it to complete ..."
-							$LogMessage = @{ hostpoolName_s = $HostpoolName; logmessage_s = "Stopping Azure VM: $VMName and waiting for it to complete ..." }
-							Add-LogEntry -LogMessageObj $LogMessage -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -logType "WVDTenantScale_CL" -TimeDifferenceInHours $TimeDifference
-							Stop-SessionHost -VMName $VMName -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -TimeDifference $TimeDifference
-						}
-						else {
-
-							# Ensure the running Azure VM is set as drain mode
+						# Ensure the running Azure VM is set as drain mode
 							try {
 								$CheckMinimumDrianMode = (Get-RdsSessionHost -TenantName $TenantName -HostPoolName $HostpoolName | Where-Object { $_.AllowNewSession -eq "True" -and $AllSessionHosts -contains $_ }).Count
 								if ($CheckMinimumDrianMode -gt $MinimumNumberOfRDSH) {
@@ -636,6 +627,14 @@ if ($LogAnalyticsWorkspaceId -and $LogAnalyticsPrimaryKey)
 								Add-LogEntry -LogMessageObj $LogMessage -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -logType "WVDTenantScale_CL" -TimeDifferenceInHours $TimeDifference
 								exit
 							}
+						if ($SessionHost.Sessions -eq 0) {
+							# Shutdown the Azure VM, which session host have 0 sessions
+							Write-Output "Stopping Azure VM: $VMName and waiting for it to complete ..."
+							$LogMessage = @{ hostpoolName_s = $HostpoolName; logmessage_s = "Stopping Azure VM: $VMName and waiting for it to complete ..." }
+							Add-LogEntry -LogMessageObj $LogMessage -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -logType "WVDTenantScale_CL" -TimeDifferenceInHours $TimeDifference
+							Stop-SessionHost -VMName $VMName -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -TimeDifference $TimeDifference
+						}
+						else {
 							if ($LimitSecondsToForceLogOffUser -eq 0) {
 								continue
 							}

--- a/wvd-templates/wvd-scaling-script/basicScale.ps1
+++ b/wvd-templates/wvd-scaling-script/basicScale.ps1
@@ -725,18 +725,7 @@ if ($LogAnalyticsWorkspaceId -and $LogAnalyticsPrimaryKey)
 									Add-LogEntry -LogMessageObj $LogMessage -LogAnalyticsWorkspaceId $LogAnalyticsWorkspaceId -LogAnalyticsPrimaryKey $LogAnalyticsPrimaryKey -logType "WVDTenantScale_CL" -TimeDifferenceInHours $TimeDifference
 								}
 							}
-							# Check if the session host status is NoHeartbeat or Unavailable
-							$IsSessionHostNoHeartbeat = $false
-							while (!$IsSessionHostNoHeartbeat) {
-								$SessionHostInfo = Get-RdsSessionHost -TenantName $TenantName -HostPoolName $HostpoolName -Name $SessionHostName
-								if ($SessionHostInfo.UpdateState -eq "Succeeded" -and $SessionHostInfo.Status -eq "NoHeartbeat" -or $SessionHost.Status -eq "Unavailable") {
-									$IsSessionHostNoHeartbeat = $true
-									# Ensure the Azure VMs that are off have allow new connections mode set to True
-									if ($SessionHostInfo.AllowNewSession -eq $false) {
-										Check-ForAllowNewConnections -TenantName $TenantName -HostPoolName $HostpoolName -SessionHostName $SessionHostName
-									}
-								}
-							}
+							
 						}
 						$RoleSize = Get-AzVMSize -Location $RoleInstance.Location | Where-Object { $_.Name -eq $RoleInstance.HardwareProfile.VmSize }
 						#decrement number of running session host
@@ -1365,18 +1354,7 @@ else {
 									Write-Output "Azure VM has been stopped: $($RoleInstance.Name) ..."
 								}
 							}
-							# Check if the session host status is NoHeartbeat or Unavailable                          
-							$IsSessionHostNoHeartbeat = $false
-							while (!$IsSessionHostNoHeartbeat) {
-								$SessionHostInfo = Get-RdsSessionHost -TenantName $TenantName -HostPoolName $HostpoolName -Name $SessionHostName
-								if ($SessionHostInfo.UpdateState -eq "Succeeded" -and $SessionHostInfo.Status -eq "NoHeartbeat" -or $SessionHostInfo.Status -eq "Unavailable") {
-									$IsSessionHostNoHeartbeat = $true
-									# Ensure the Azure VMs that are off have allow new connections mode set to True
-									if ($SessionHostInfo.AllowNewSession -eq $false) {
-										Check-ForAllowNewConnections -TenantName $TenantName -HostPoolName $HostpoolName -SessionHostName $SessionHostName
-									}
-								}
-							}
+							
 						}
 						$RoleSize = Get-AzVMSize -Location $RoleInstance.Location | Where-Object { $_.Name -eq $RoleInstance.HardwareProfile.VmSize }
 						#decrement number of running session host


### PR DESCRIPTION
this changes set the AllowNewSession flag as $false even if the session host has no user session.
This way the rdbroker avoid to send new user sessions before the shutdown process. Currently this flag is only set to false if we have active user sessions in the session host