### PR TITLE
RDSH VM name prefix refactor

### DIFF
--- a/wvd-templates/Create and provision WVD host pool/mainTemplate.json
+++ b/wvd-templates/Create and provision WVD host pool/mainTemplate.json
@@ -79,8 +79,7 @@
             "type": "string",
             "metadata": {
                 "description": "This prefix will be used in combination with the VM number to create the VM name. If using 'rdsh' as the prefix, VMs would be named 'rdsh-0', 'rdsh-1', etc. You should use a unique prefix to reduce name collisions in Active Directory. Warning: Please note that starting from June 1st 2020, the default value for this parameter will be removed, so the value will need to be specified"
-            },
-            "defaultValue": "[take(toLower(resourceGroup().name), 10)]"
+            }
         },
         "rdshNumberOfInstances": {
             "type": "int",

--- a/wvd-templates/Update existing WVD host pool/README.md
+++ b/wvd-templates/Update existing WVD host pool/README.md
@@ -71,7 +71,7 @@ Ignore the following parameters:
 Enter the remaining configuration parameters for the virtual machines.
 - **Vm Size**
 - **Enable Accelerated Networking**. Please notice that VM size must support it, this is supported in most of general purpose and compute-optimized instances with 2 or more vCPUs, on instances that supports hyperthreading it is required minimum of 4 vCPUs. Default value is `false`.
-- **Rdsh Name Prefix**
+- **Rdsh Name Prefix**. This prefix must be unique and can't be same as the existing VMs because this template is designed to create new VMs with the specified prefix name and delete/deallocate any other existing VMs from the host pool
   > [!WARNING]
   Starting from **June 1st 2020**, this parameter will be renamed to **newRdshNamePrefix** and the default value for this parameter will be removed, so the value will need to be specified.
 - **Rdsh Number Of Instances**

--- a/wvd-templates/Update existing WVD host pool/README.md
+++ b/wvd-templates/Update existing WVD host pool/README.md
@@ -71,7 +71,7 @@ Ignore the following parameters:
 Enter the remaining configuration parameters for the virtual machines.
 - **Vm Size**
 - **Enable Accelerated Networking**. Please notice that VM size must support it, this is supported in most of general purpose and compute-optimized instances with 2 or more vCPUs, on instances that supports hyperthreading it is required minimum of 4 vCPUs. Default value is `false`.
-- **Rdsh Name Prefix**. This prefix must be unique and can't be same as the existing VMs because this template is designed to create new VMs with the specified prefix name and delete/deallocate any other existing VMs from the host pool
+- **New Rdsh Name Prefix**. This prefix must be unique and can't be same as the existing VMs because this template is designed to create new VMs with the specified prefix name and delete/deallocate any other existing VMs from the host pool
   > [!WARNING]
   Starting from **June 1st 2020**, this parameter will be renamed to **newRdshNamePrefix** and the default value for this parameter will be removed, so the value will need to be specified.
 - **Rdsh Number Of Instances**

--- a/wvd-templates/Update existing WVD host pool/mainTemplate.json
+++ b/wvd-templates/Update existing WVD host pool/mainTemplate.json
@@ -68,12 +68,11 @@
                 "description": "(Required when rdshImageSource = CustomImage) Resource group name for the managed disk, if you choose to provide one."
             }
         },
-        "rdshNamePrefix": {
+        "newRdshNamePrefix": {
             "type": "string",
             "metadata": {
-                "description": "This prefix will be used in combination with the VM number to create the VM name. If using 'rdsh' as the prefix, VMs would be named 'rdsh-0', 'rdsh-1', etc. You should use a unique prefix to reduce name collisions in Active Directory. Warning: Please note that starting from June 1st 2020, this parameter will be renamed to 'newRdshNamePrefix' and the default value will be removed, so the value will need to be specified"
-            },
-            "defaultValue": "[take(toLower(resourceGroup().name), 10)]"
+                "description": "This prefix will be used in combination with the VM number to create the VM name for the new VMs. If using 'rdsh' as the prefix, VMs would be named 'rdsh-0', 'rdsh-1', etc. This prefix must be unique and can't be same as the existing VMs because this template is designed to create new VMs with the specified prefix name and delete/deallocate any other existing VMs from the host pool. You should use a unique prefix to reduce name collisions in Active Directory. Warning: Please note that starting from June 1st 2020, this parameter will be renamed to 'newRdshNamePrefix' and the default value will be removed, so the value will need to be specified"
+            }
         },
         "rdshNumberOfInstances": {
             "type": "int",
@@ -292,7 +291,7 @@
         }
     },
     "variables": {
-        "rdshPrefix": "[concat(parameters('rdshNamePrefix'), '-')]",
+        "rdshPrefix": "[concat(parameters('newRdshNamePrefix'), '-')]",
         "existingDomainUsername": "[first(split(parameters('existingDomainUPN'), '@'))]",
         "subnet-id": "[resourceId(parameters('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('existingVnetName'), parameters('existingSubnetName'))]",
         "existingTenantName": "[replace(parameters('existingTenantName'), '\"', '')]",


### PR DESCRIPTION
* Remove default value of `rdshNamePrefix` param in both create & update templates.
* In update templates, rename the param to `newRdshNamePrefix` & clarify that it must be unique in the param desc and in read me file