### PR TITLE
fix webhook URI getting corrupted when setting the auto var with out-string version of URI

### DIFF
--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
@@ -2,7 +2,7 @@
 <#
 .SYNOPSIS
 	This is a sample script to deploy the required resources to execute scaling script in Microsoft Azure Automation Account.
-	v0.1.4
+	v0.1.5
 	# //todo refactor stuff from https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-5.1
 #>
 param(
@@ -228,8 +228,7 @@ $WebhookURI = Get-AzAutomationVariable -Name $WebhookURIAutoVarName -ResourceGro
 if (!$WebhookURI) {
 	$Webhook = New-AzAutomationWebhook -Name $WebhookName -RunbookName $RunbookName -IsEnabled $true -ExpiryTime (Get-Date).AddYears(5) -ResourceGroupName $ResourceGroupName -AutomationAccountName $AutomationAccountName -Force -Verbose
 	Write-Output "Automation Account Webhook is created with name '$WebhookName'"
-	$URIofWebhook = $Webhook.WebhookURI | Out-String
-	New-AzAutomationVariable -Name $WebhookURIAutoVarName -Encrypted $false -ResourceGroupName $ResourceGroupName -AutomationAccountName $AutomationAccountName -Value $URIofWebhook
+	New-AzAutomationVariable -Name $WebhookURIAutoVarName -Encrypted $false -ResourceGroupName $ResourceGroupName -AutomationAccountName $AutomationAccountName -Value $Webhook.WebhookURI
 	Write-Output "Webhook URI stored in Azure Automation Acccount variables"
 	$WebhookURI = Get-AzAutomationVariable -Name $WebhookURIAutoVarName -ResourceGroupName $ResourceGroupName -AutomationAccountName $AutomationAccountName -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
When creating a new automation variable for storing the webhook URI in Azure Automation Account using `Az.Automation` PowerShell module with version 1.3.7 and later, `New-AzAutomationVariable` corrupts the argument `Value` of the string variable if that string variable is created by `Out-String`. The fix is to use the string directly without using `Out-String` on it.