### PR TITLE
WVD Scaling Tool: conditionally set PS exec policy to support CloudShell in deployment scripts

### DIFF
--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
@@ -46,8 +46,10 @@ if (!$UseRDSAPI) {
 	$WebhookName += 'ARMBased'
 }
 
-# Set the ExecutionPolicy
-Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Confirm:$false
+# Set the ExecutionPolicy if not being ran in CloudShell as this command fails in CloudShell
+if (-not ($env:POWERSHELL_DISTRIBUTION_CHANNEL -eq 'CloudShell') {
+	Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Confirm:$false
+}
 
 # Import Az and AzureAD modules
 Import-Module Az.Resources

--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
@@ -2,7 +2,7 @@
 <#
 .SYNOPSIS
 	This is a sample script to deploy the required resources to execute scaling script in Microsoft Azure Automation Account.
-	v0.1.5
+	v0.1.6
 	# //todo refactor stuff from https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-5.1
 #>
 param(

--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
@@ -47,7 +47,7 @@ if (!$UseRDSAPI) {
 }
 
 # Set the ExecutionPolicy if not being ran in CloudShell as this command fails in CloudShell
-if (-not ($env:POWERSHELL_DISTRIBUTION_CHANNEL -eq 'CloudShell') {
+if ($env:POWERSHELL_DISTRIBUTION_CHANNEL -ne 'CloudShell') {
 	Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Confirm:$false
 }
 

--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzLogicApp.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzLogicApp.ps1
@@ -99,8 +99,10 @@ if (!$HostPoolResourceGroupName) {
 	$HostPoolResourceGroupName = $ResourceGroupName
 }
 
-# Set the ExecutionPolicy
-Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Confirm:$false
+# Set the ExecutionPolicy if not being ran in CloudShell as this command fails in CloudShell
+if ($env:POWERSHELL_DISTRIBUTION_CHANNEL -ne 'CloudShell') {
+	Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Confirm:$false
+}
 
 # Import Az and AzureAD modules
 Import-Module Az.LogicApp

--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzLogicApp.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzLogicApp.ps1
@@ -2,7 +2,7 @@
 <#
 .SYNOPSIS
 	This is a sample script to deploy the required resources to schedule basic scale in Microsoft Azure.
-	v0.1.4
+	v0.1.5
 	# //todo refactor stuff from https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-5.1
 #>
 param(


### PR DESCRIPTION
update WVD scaling tool deployment scripts to conditionally set the execution policy to account for running the script from cloud shell.