### PR TITLE
Remove public ip parameter from ARM templates

### DIFF
--- a/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
+++ b/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
@@ -7,14 +7,14 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/nestedtemplates/"
+            "defaultValue": "https://catalogartifact.azureedge.net/publicartifacts/Microsoft.Hostpool-ARM-1.0.16-preview/"
         },
         "artifactsLocation": {
             "type": "string",
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
+            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
         },
         "hostpoolName": {
             "type": "string",
@@ -201,35 +201,6 @@
                 "description": "The resource group containing the existing virtual network."
             }
         },
-        "usePublicIP": {
-            "type": "bool",
-            "metadata": {
-                "description": "Whether to use a Public IP"
-            },
-            "defaultValue": false
-        },
-        "publicIpAddressSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The sku name of the Public IP"
-            },
-            "allowedValues": [
-                "Basic",
-                "Standard"
-            ],
-            "defaultValue": "Basic"
-        },
-        "publicIpAddressType": {
-            "type": "string",
-            "metadata": {
-                "description": "The address type of the Public IP"
-            },
-            "allowedValues": [
-                "Dynamic",
-                "Static"
-            ],
-            "defaultValue": "Dynamic"
-        },
         "createNetworkSecurityGroup": {
             "type": "bool",
             "metadata": {
@@ -269,13 +240,6 @@
             "type": "object",
             "metadata": {
                 "description": "The tags to be assigned to the network security groups"
-            },
-            "defaultValue": {}
-        },
-        "publicIPAddressTags": {
-            "type": "object",
-            "metadata": {
-                "description": "The tags to be assigned to the public ip addresses"
             },
             "defaultValue": {}
         },
@@ -467,15 +431,6 @@
                     "location": {
                         "value": "[parameters('vmLocation')]"
                     },
-                    "usePublicIP": {
-                        "value": "[parameters('usePublicIP')]"
-                    },
-                    "publicIpAddressType": {
-                        "value": "[parameters('publicIpAddressType')]"
-                    },
-                    "publicIpAddressSku": {
-                        "value": "[parameters('publicIpAddressSku')]"
-                    },
                     "createNetworkSecurityGroup": {
                         "value": "[parameters('createNetworkSecurityGroup')]"
                     },
@@ -490,9 +445,6 @@
                     },
                     "networkSecurityGroupTags": {
                         "value": "[parameters('networkSecurityGroupTags')]"
-                    },
-                    "publicIPAddressTags": {
-                        "value": "[parameters('publicIPAddressTags')]"
                     },
                     "virtualMachineTags": {
                         "value": "[parameters('virtualMachineTags')]"

--- a/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
+++ b/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
@@ -7,14 +7,14 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://catalogartifact.azureedge.net/publicartifacts/Microsoft.Hostpool-ARM-1.0.16-preview/"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/nestedtemplates/"
         },
         "artifactsLocation": {
             "type": "string",
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
         },
         "hostpoolName": {
             "type": "string",

--- a/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
+++ b/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
@@ -7,14 +7,14 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located."
       },
-      "defaultValue": "https://catalogartifact.azureedge.net/publicartifacts/Microsoft.Hostpool-ARM-1.0.16-preview/"
+      "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/nestedtemplates/"
     },
     "artifactsLocation": {
       "type": "string",
       "metadata": {
         "description": "The base URI where artifacts required by this template are located."
       },
-      "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+      "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
     },
     "hostpoolName": {
       "type": "string",

--- a/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
+++ b/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
@@ -7,14 +7,14 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located."
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/nestedtemplates/"
+      "defaultValue": "https://catalogartifact.azureedge.net/publicartifacts/Microsoft.Hostpool-ARM-1.0.16-preview/"
     },
     "artifactsLocation": {
       "type": "string",
       "metadata": {
         "description": "The base URI where artifacts required by this template are located."
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
+      "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
     },
     "hostpoolName": {
       "type": "string",
@@ -226,35 +226,6 @@
       },
       "defaultValue": ""
     },
-    "usePublicIP": {
-      "type": "bool",
-      "metadata": {
-        "description": "Whether to use a Public IP"
-      },
-      "defaultValue": false
-    },
-    "publicIpAddressSku": {
-      "type": "string",
-      "metadata": {
-        "description": "The sku name of the Public IP"
-      },
-      "allowedValues": [
-        "Basic",
-        "Standard"
-      ],
-      "defaultValue": "Basic"
-    },
-    "publicIpAddressType": {
-      "type": "string",
-      "metadata": {
-        "description": "The address type of the Public IP"
-      },
-      "allowedValues": [
-        "Dynamic",
-        "Static"
-      ],
-      "defaultValue": "Dynamic"
-    },
     "createNetworkSecurityGroup": {
       "type": "bool",
       "metadata": {
@@ -369,13 +340,6 @@
       "type": "object",
       "metadata": {
         "description": "The tags to be assigned to the network security groups"
-      },
-      "defaultValue": {}
-    },
-    "publicIPAddressTags": {
-      "type": "object",
-      "metadata": {
-        "description": "The tags to be assigned to the public ip addresses"
       },
       "defaultValue": {}
     },
@@ -634,15 +598,6 @@
           "location": {
             "value": "[parameters('vmLocation')]"
           },
-          "usePublicIP": {
-            "value": "[parameters('usePublicIP')]"
-          },
-          "publicIpAddressType": {
-            "value": "[parameters('publicIpAddressType')]"
-          },
-          "publicIpAddressSku": {
-            "value": "[parameters('publicIpAddressSku')]"
-          },
           "createNetworkSecurityGroup": {
             "value": "[parameters('createNetworkSecurityGroup')]"
           },
@@ -657,9 +612,6 @@
           },
           "networkSecurityGroupTags": {
             "value": "[parameters('networkSecurityGroupTags')]"
-          },
-          "publicIPAddressTags": {
-            "value": "[parameters('publicIPAddressTags')]"
           },
           "virtualMachineTags": {
             "value": "[parameters('virtualMachineTags')]"

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -114,29 +114,6 @@
                 "description": "Location for all resources to be created in."
             }
         },
-        "usePublicIP":{
-            "type": "bool",
-            "metadata": {
-                "description": "Whether to use a Public IP"
-            },
-            "defaultValue": false
-        },
-        "publicIpAddressType": {
-            "type": "string",
-            "metadata": {
-                "description": "The address type of the Public IP"
-            },
-            "allowedValues": ["Dynamic", "Static"],
-            "defaultValue": "Dynamic"
-        },
-        "publicIpAddressSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The sku name of the Public IP"
-            },
-            "allowedValues": ["Basic", "Standard"],
-            "defaultValue": "Basic"
-        },
         "createNetworkSecurityGroup":{
             "type": "bool",
             "metadata":{
@@ -169,13 +146,6 @@
             "type": "object",
             "metadata": {
                 "description": "The tags to be assigned to the network security groups"
-            },
-            "defaultValue": {}
-        },
-        "publicIPAddressTags": {
-            "type": "object",
-            "metadata": {
-                "description": "The tags to be assigned to the public ip addresses"
             },
             "defaultValue": {}
         },
@@ -265,24 +235,6 @@
             }
         },
         {
-            "copy": {
-                "name": "rdsh-pip-loop",
-                "count": "[parameters('rdshNumberOfInstances')]"
-            },
-            "condition": "[parameters('usePublicIP')]",
-            "type": "Microsoft.Network/publicIpAddresses",
-            "apiVersion": "2019-02-01",
-            "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')]",
-            "location": "[parameters('location')]",
-            "tags": "[parameters('publicIPAddressTags')]",
-            "sku": {
-                "name": "[parameters('publicIpAddressSku')]"
-            },
-            "properties": {
-                "publicIpAllocationMethod": "[parameters('publicIpAddressType')]"
-            }
-        },
-        {
             "apiVersion": "2018-11-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-nic')]",
@@ -300,8 +252,7 @@
                             "privateIPAllocationMethod": "Dynamic",
                             "subnet": {
                                 "id": "[parameters('subnet-id')]"
-                            },
-                            "publicIpAddress": "[if(parameters('usePublicIP'), json(concat('{\"id\": \"', resourceId('Microsoft.Network/publicIpAddresses', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')), '\"}')), json('null'))]"
+                            }
                         }
                     }
                 ],
@@ -309,8 +260,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate",
-                "rdsh-pip-loop"
+                "NSG-linkedTemplate"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -114,29 +114,6 @@
                 "description": "Location for all resources to be created in."
             }
         },
-        "usePublicIP":{
-            "type": "bool",
-            "metadata": {
-                "description": "Whether to use a Public IP"
-            },
-            "defaultValue": false
-        },
-        "publicIpAddressType": {
-            "type": "string",
-            "metadata": {
-                "description": "The address type of the Public IP"
-            },
-            "allowedValues": ["Dynamic", "Static"],
-            "defaultValue": "Dynamic"
-        },
-        "publicIpAddressSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The sku name of the Public IP"
-            },
-            "allowedValues": ["Basic", "Standard"],
-            "defaultValue": "Basic"
-        },
         "createNetworkSecurityGroup":{
             "type": "bool",
             "metadata":{
@@ -169,13 +146,6 @@
             "type": "object",
             "metadata": {
                 "description": "The tags to be assigned to the network security groups"
-            },
-            "defaultValue": {}
-        },
-        "publicIPAddressTags": {
-            "type": "object",
-            "metadata": {
-                "description": "The tags to be assigned to the public ip addresses"
             },
             "defaultValue": {}
         },
@@ -281,24 +251,6 @@
                     ]
                 }
             }
-        }, 
-        {
-            "copy": {
-                "name": "rdsh-pip-loop",
-                "count": "[parameters('rdshNumberOfInstances')]"
-            },
-            "condition": "[parameters('usePublicIP')]",
-            "type": "Microsoft.Network/publicIpAddresses",
-            "apiVersion": "2019-02-01",
-            "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')]",
-            "location": "[parameters('location')]",
-            "tags": "[parameters('publicIPAddressTags')]",
-            "sku": {
-                "name": "[parameters('publicIpAddressSku')]"
-            },
-            "properties": {
-                "publicIpAllocationMethod": "[parameters('publicIpAddressType')]"
-            }
         },
         {
             "apiVersion": "2018-11-01",
@@ -318,8 +270,7 @@
                             "privateIPAllocationMethod": "Dynamic",
                             "subnet": {
                                 "id": "[parameters('subnet-id')]"
-                            },
-                            "publicIpAddress": "[if(parameters('usePublicIP'), json(concat('{\"id\": \"', resourceId('Microsoft.Network/publicIpAddresses', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')), '\"}')), json('null'))]"
+                            }
                         }
                     }
                 ],
@@ -327,8 +278,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate",
-                "rdsh-pip-loop"
+                "NSG-linkedTemplate"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -114,29 +114,6 @@
                 "description": "Location for all resources to be created in."
             }
         },
-        "usePublicIP":{
-            "type": "bool",
-            "metadata": {
-                "description": "Whether to use a Public IP"
-            },
-            "defaultValue": false
-        },
-        "publicIpAddressType": {
-            "type": "string",
-            "metadata": {
-                "description": "The address type of the Public IP"
-            },
-            "allowedValues": ["Dynamic", "Static"],
-            "defaultValue": "Dynamic"
-        },
-        "publicIpAddressSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The sku name of the Public IP"
-            },
-            "allowedValues": ["Basic", "Standard"],
-            "defaultValue": "Basic"
-        },
         "createNetworkSecurityGroup":{
             "type": "bool",
             "metadata":{
@@ -169,13 +146,6 @@
             "type": "object",
             "metadata": {
                 "description": "The tags to be assigned to the network security groups"
-            },
-            "defaultValue": {}
-        },
-        "publicIPAddressTags": {
-            "type": "object",
-            "metadata": {
-                "description": "The tags to be assigned to the public ip addresses"
             },
             "defaultValue": {}
         },
@@ -265,24 +235,6 @@
             }
         },
         {
-            "copy": {
-                "name": "rdsh-pip-loop",
-                "count": "[parameters('rdshNumberOfInstances')]"
-            },
-            "condition": "[parameters('usePublicIP')]",
-            "type": "Microsoft.Network/publicIpAddresses",
-            "apiVersion": "2019-02-01",
-            "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')]",
-            "location": "[parameters('location')]",
-            "tags": "[parameters('publicIPAddressTags')]",
-            "sku": {
-                "name": "[parameters('publicIpAddressSku')]"
-            },
-            "properties": {
-                "publicIpAllocationMethod": "[parameters('publicIpAddressType')]"
-            }
-        },
-        {
             "apiVersion": "2018-11-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-nic')]",
@@ -300,8 +252,7 @@
                             "privateIPAllocationMethod": "Dynamic",
                             "subnet": {
                                 "id": "[parameters('subnet-id')]"
-                            },
-                            "publicIpAddress": "[if(parameters('usePublicIP'), json(concat('{\"id\": \"', resourceId('Microsoft.Network/publicIpAddresses', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')), '\"}')), json('null'))]"
+                            }
                         }
                     }
                 ],
@@ -309,8 +260,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate",
-                "rdsh-pip-loop"
+                "NSG-linkedTemplate"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -114,29 +114,6 @@
                 "description": "Location for all resources to be created in."
             }
         },
-        "usePublicIP":{
-            "type": "bool",
-            "metadata": {
-                "description": "Whether to use a Public IP"
-            },
-            "defaultValue": false
-        },
-        "publicIpAddressType": {
-            "type": "string",
-            "metadata": {
-                "description": "The address type of the Public IP"
-            },
-            "allowedValues": ["Dynamic", "Static"],
-            "defaultValue": "Dynamic"
-        },
-        "publicIpAddressSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The sku name of the Public IP"
-            },
-            "allowedValues": ["Basic", "Standard"],
-            "defaultValue": "Basic"
-        },
         "createNetworkSecurityGroup":{
             "type": "bool",
             "metadata":{
@@ -169,13 +146,6 @@
             "type": "object",
             "metadata": {
                 "description": "The tags to be assigned to the network security groups"
-            },
-            "defaultValue": {}
-        },
-        "publicIPAddressTags": {
-            "type": "object",
-            "metadata": {
-                "description": "The tags to be assigned to the public ip addresses"
             },
             "defaultValue": {}
         },
@@ -266,24 +236,6 @@
             }
         },
         {
-            "copy": {
-                "name": "rdsh-pip-loop",
-                "count": "[parameters('rdshNumberOfInstances')]"
-            },
-            "condition": "[parameters('usePublicIP')]",
-            "type": "Microsoft.Network/publicIpAddresses",
-            "apiVersion": "2019-02-01",
-            "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')]",
-            "location": "[parameters('location')]",
-            "tags": "[parameters('publicIPAddressTags')]",
-            "sku": {
-                "name": "[parameters('publicIpAddressSku')]"
-            },
-            "properties": {
-                "publicIpAllocationMethod": "[parameters('publicIpAddressType')]"
-            }
-        },
-        {
             "apiVersion": "2018-11-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-nic')]",
@@ -301,8 +253,7 @@
                             "privateIPAllocationMethod": "Dynamic",
                             "subnet": {
                                 "id": "[parameters('subnet-id')]"
-                            },
-                            "publicIpAddress": "[if(parameters('usePublicIP'), json(concat('{\"id\": \"', resourceId('Microsoft.Network/publicIpAddresses', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '-ip')), '\"}')), json('null'))]"
+                            }
                         }
                     }
                 ],
@@ -310,8 +261,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate",
-                "rdsh-pip-loop"
+                "NSG-linkedTemplate"
             ]
         },
         {


### PR DESCRIPTION
The best practice for WVD scenario is to NOT use public ip when creating VMs in a host pool.  Therefore we remove public IP parameter from WVD ARM templates.