### PR TITLE
Updated dsc version to force use TLS1.2 and be github compatible

### DIFF
--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -404,7 +404,7 @@
             "properties": {
                 "publisher": "Microsoft.Powershell",
                 "type": "DSC",
-                "typeHandlerVersion": "2.73",
+                "typeHandlerVersion": "2.75",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "modulesUrl": "[parameters('artifactsLocation')]",

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -423,7 +423,7 @@
             "properties": {
                 "publisher": "Microsoft.Powershell",
                 "type": "DSC",
-                "typeHandlerVersion": "2.73",
+                "typeHandlerVersion": "2.75",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "modulesUrl": "[parameters('artifactsLocation')]",

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -407,7 +407,7 @@
             "properties": {
                 "publisher": "Microsoft.Powershell",
                 "type": "DSC",
-                "typeHandlerVersion": "2.73",
+                "typeHandlerVersion": "2.75",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "modulesUrl": "[parameters('artifactsLocation')]",

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -408,7 +408,7 @@
             "properties": {
                 "publisher": "Microsoft.Powershell",
                 "type": "DSC",
-                "typeHandlerVersion": "2.73",
+                "typeHandlerVersion": "2.75",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "modulesUrl": "[parameters('artifactsLocation')]",


### PR DESCRIPTION
As per this article, you can't use the DSCextension version 2.73 with GitHub hosted configuration / modules.

https://docs.microsoft.com/en-us/azure/automation/automation-dsc-extension-history

Upgrading to version will resolve the issue.