### PR TITLE
add optional local VM admin parameters to ARM WVD templates

### DIFF
--- a/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
+++ b/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
@@ -68,6 +68,20 @@
                 "description": "The password that corresponds to the existing domain username."
             }
         },
+        "vmAdministratorAccountUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "A username to be used as the virtual machine administrator account. The domain administrator username will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
+        "vmAdministratorAccountPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password associated with the virtual machine administrator account. The domain administrator password will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
         "createAvailabilitySet": {
             "type": "bool",
             "metadata": {
@@ -290,7 +304,6 @@
         "rdshManagedDisks": "[if(equals(parameters('vmImageType'), 'CustomVHD'), parameters('vmUseManagedDisks'), bool('true'))]",
         "rdshPrefix": "[concat(parameters('vmNamePrefix'),'-')]",
         "avSetSKU": "[if(variables('rdshManagedDisks'), 'Aligned', 'Classic')]",
-        "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
         "vhds": "[concat('vhds','/', variables('rdshPrefix'))]",
         "subnet-id": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets',parameters('existingVnetName'), parameters('existingSubnetName'))]",
         "hostpoolName": "[replace(parameters('hostpoolName'),'\"','')]",
@@ -412,6 +425,12 @@
                     },
                     "enableAcceleratedNetworking": {
                         "value": false
+                    },
+                    "vmAdministratorAccountUsername": {
+                        "value":  "[parameters('vmAdministratorAccountUsername')]"
+                    },
+                    "vmAdministratorAccountPassword": {
+                        "value": "[parameters('vmAdministratorAccountPassword')]"
                     },
                     "administratorAccountUsername": {
                         "value": "[parameters('administratorAccountUsername')]"

--- a/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
+++ b/ARM-wvd-templates/AddVirtualMachinesToHostPool/AddVirtualMachinesTemplate.json
@@ -71,14 +71,14 @@
         "vmAdministratorAccountUsername": {
             "type": "string",
             "metadata": {
-                "description": "A username to be used as the virtual machine administrator account. The domain administrator username will be used if this parameter is not provided."
+                "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },
         "vmAdministratorAccountPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "The password associated with the virtual machine administrator account. The domain administrator password will be used if this parameter is not provided."
+                "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },

--- a/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
+++ b/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
@@ -93,14 +93,14 @@
     "vmAdministratorAccountUsername": {
       "type": "string",
       "metadata": {
-        "description": "A username to be used as the virtual machine administrator account. The domain administrator username will be used if this parameter is not provided."
+        "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
       },
       "defaultValue": ""
     },
     "vmAdministratorAccountPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "The password associated with the virtual machine administrator account. The domain administrator password will be used if this parameter is not provided."
+        "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
       },
       "defaultValue": ""
     },

--- a/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
+++ b/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
@@ -90,6 +90,20 @@
       },
       "defaultValue": ""
     },
+    "vmAdministratorAccountUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "A username to be used as the virtual machine administrator account. The domain administrator username will be used if this parameter is not provided."
+      },
+      "defaultValue": ""
+    },
+    "vmAdministratorAccountPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password associated with the virtual machine administrator account. The domain administrator password will be used if this parameter is not provided."
+      },
+      "defaultValue": ""
+    },
     "createAvailabilitySet": {
       "type": "bool",
       "metadata": {
@@ -405,7 +419,6 @@
     "rdshManagedDisks": "[if(equals(parameters('vmImageType'), 'CustomVHD'), parameters('vmUseManagedDisks'), bool('true'))]",
     "rdshPrefix": "[concat(parameters('vmNamePrefix'),'-')]",
     "avSetSKU": "[if(variables('rdshManagedDisks'), 'Aligned', 'Classic')]",
-    "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
     "vhds": "[concat('vhds','/', variables('rdshPrefix'))]",
     "subnet-id": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets',parameters('existingVnetName'), parameters('existingSubnetName'))]",
     "hostpoolName": "[replace(parameters('hostpoolName'),'\"','')]",
@@ -579,6 +592,12 @@
           },
           "enableAcceleratedNetworking": {
             "value": false
+          },
+          "vmAdministratorAccountUsername": {
+            "value": "[parameters('vmAdministratorAccountUsername')]"
+          },
+          "vmAdministratorAccountPassword": {
+            "value": "[parameters('vmAdministratorAccountPassword')]"
           },
           "administratorAccountUsername": {
             "value": "[parameters('administratorAccountUsername')]"

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -91,14 +91,14 @@
         "vmAdministratorAccountUsername": {
             "type": "string",
             "metadata": {
-                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+                "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },
         "vmAdministratorAccountPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+                "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
         },
         "VmImageVhdUri": {
             "type": "string",
@@ -87,6 +87,20 @@
             "metadata": {
                 "description": "The password that corresponds to the existing domain username."
             }
+        },
+        "vmAdministratorAccountUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
+        "vmAdministratorAccountPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
         },
         "vhds": {
             "type": "string",
@@ -202,11 +216,13 @@
         }
     },
     "variables": {
-        "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
-        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]"
+        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
+        "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
+        "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
+        "vmAdministratorPassword": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountPassword'), parameters('administratorAccountPassword'))]"
     },
     "resources": [
         {
@@ -285,8 +301,8 @@
                 },
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')))]",
-                    "adminUsername": "[variables('existingDomainUsername')]",
-                    "adminPassword": "[parameters('administratorAccountPassword')]"
+                    "adminUsername": "[variables('vmAdministratorUsername')]",
+                    "adminPassword": "[variables('vmAdministratorPassword')]"
                 },
                 "storageProfile": {
                     "osDisk": {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -91,14 +91,14 @@
         "vmAdministratorAccountUsername": {
             "type": "string",
             "metadata": {
-                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+                "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },
         "vmAdministratorAccountPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+                "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
         },
         "VmImageVhdUri": {
             "type": "string",
@@ -87,6 +87,20 @@
             "metadata": {
                 "description": "The password that corresponds to the existing domain username."
             }
+        },
+        "vmAdministratorAccountUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
+        "vmAdministratorAccountPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
         },
         "vhds": {
             "type": "string",
@@ -202,12 +216,14 @@
         }
     },
     "variables": {
-        "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "imageName": "[concat(parameters('rdshPrefix'), 'image')]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
-        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]"
+        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
+        "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
+        "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
+        "vmAdministratorPassword": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountPassword'), parameters('administratorAccountPassword'))]"
     },
     "resources": [
         {
@@ -304,8 +320,8 @@
                 },
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')))]",
-                    "adminUsername": "[variables('existingDomainUsername')]",
-                    "adminPassword": "[parameters('administratorAccountPassword')]"
+                    "adminUsername": "[variables('vmAdministratorUsername')]",
+                    "adminPassword": "[variables('vmAdministratorPassword')]"
                 },
                 "storageProfile": {
                     "osDisk": {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
         },
         "VmImageVhdUri": {
             "type": "string",
@@ -87,6 +87,20 @@
             "metadata": {
                 "description": "The password that corresponds to the existing domain username."
             }
+        },
+        "vmAdministratorAccountUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
+        "vmAdministratorAccountPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
         },
         "vhds": {
             "type": "string",
@@ -202,11 +216,13 @@
         }
     },
     "variables": {
-        "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",        
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
-        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]"
+        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
+        "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
+        "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
+        "vmAdministratorPassword": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountPassword'), parameters('administratorAccountPassword'))]"
     },
     "resources": [
         {
@@ -285,8 +301,8 @@
                 },
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')))]",
-                    "adminUsername": "[variables('existingDomainUsername')]",
-                    "adminPassword": "[parameters('administratorAccountPassword')]"
+                    "adminUsername": "[variables('vmAdministratorUsername')]",
+                    "adminPassword": "[variables('vmAdministratorPassword')]"
                 },
                 "storageProfile": {
                     "imageReference": {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -91,14 +91,14 @@
         "vmAdministratorAccountUsername": {
             "type": "string",
             "metadata": {
-                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+                "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },
         "vmAdministratorAccountPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+                "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -91,14 +91,14 @@
         "vmAdministratorAccountUsername": {
             "type": "string",
             "metadata": {
-                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+                "description": "A username to be used as the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },
         "vmAdministratorAccountPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+                "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
             },
             "defaultValue": ""
         },

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located."
             },
-            "defaultValue": "https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration.zip"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/RDS-Templates/master/ARM-wvd-templates/DSC/Configuration.zip"
         },
         "VmImageVhdUri": {
             "type": "string",
@@ -87,6 +87,20 @@
             "metadata": {
                 "description": "The password that corresponds to the existing domain username."
             }
+        },
+        "vmAdministratorAccountUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The virtual machine admin user name. The domain administrator username will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
+        },
+        "vmAdministratorAccountPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The virtual machine admin password. The domain administrator password will be used if this parameter is not provided."
+            },
+            "defaultValue": ""
         },
         "vhds": {
             "type": "string",
@@ -202,12 +216,14 @@
         }
     },
     "variables": {
-        "existingDomainUsername": "[first(split(parameters('administratorAccountUsername'), '@'))]",
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountName": "[split( split( parameters('VmImageVhdUri'), '/')[2], '.' )[0]]",
         "storageaccount": "[concat(resourceId(parameters('storageAccountResourceGroupName'),'Microsoft.Storage/storageAccounts',variables('storageAccountName')))]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
-        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]"
+        "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
+        "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
+        "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
+        "vmAdministratorPassword": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountPassword'), parameters('administratorAccountPassword'))]"
     },
     "resources": [
         {
@@ -286,8 +302,8 @@
                 },
                 "osProfile": {
                     "computerName": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')))]",
-                    "adminUsername": "[variables('existingDomainUsername')]",
-                    "adminPassword": "[parameters('administratorAccountPassword')]"
+                    "adminUsername": "[variables('vmAdministratorUsername')]",
+                    "adminPassword": "[variables('vmAdministratorPassword')]"
                 },
                 "storageProfile": {
                     "osDisk": {


### PR DESCRIPTION
This PR contains changes that will allow the users to provide an optional vm admin credentials that will be used to create a local admin user on the VM. If this parameter is not provided, then administrator account credentials will be used for both domain join as well as creating the local user on the VM.