### PR TITLE
Updated linked templates to include deployment guid in deployment name

### DIFF
--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -227,7 +227,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "NSG-linkedTemplate",
+            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -219,6 +219,7 @@
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
+        "newNsgDeploymentName": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
         "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
         "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
         "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
@@ -227,7 +228,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
+            "name": "[variables('newNsgDeploymentName')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -276,7 +277,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate"
+                "[variables('newNsgDeploymentName')]"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -245,7 +245,7 @@
         },
         {
             "apiVersion": "2018-05-01",
-            "name": "NSG-linkedTemplate",
+            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customvhdvm.json
@@ -220,6 +220,7 @@
         "storageAccountType": "[parameters('rdshVMDiskType')]",
         "imageName": "[concat(parameters('rdshPrefix'), 'image')]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
+        "newNsgDeploymentName": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]"
         "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
         "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
         "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
@@ -245,7 +246,7 @@
         },
         {
             "apiVersion": "2018-05-01",
-            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
+            "name": "[variables('newNsgDeploymentName')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -294,7 +295,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate"
+                "[variables('newNsgDeploymentName')]"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -227,7 +227,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "NSG-linkedTemplate",
+            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",

--- a/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-galleryvm.json
@@ -219,6 +219,7 @@
         "domain": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
         "storageAccountType": "[parameters('rdshVMDiskType')]",        
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
+        "newNsgDeploymentName": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
         "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
         "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
         "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
@@ -227,7 +228,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
+            "name": "[variables('newNsgDeploymentName')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -276,7 +277,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate"
+                "[variables('newNsgDeploymentName')]"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -220,6 +220,7 @@
         "storageAccountName": "[split( split( parameters('VmImageVhdUri'), '/')[2], '.' )[0]]",
         "storageaccount": "[concat(resourceId(parameters('storageAccountResourceGroupName'),'Microsoft.Storage/storageAccounts',variables('storageAccountName')))]",
         "newNsgName": "[concat(parameters('rdshPrefix'), 'nsg-', parameters('_guidValue'))]",
+        "newNsgDeploymentName": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]"
         "nsgId": "[if(parameters('createNetworkSecurityGroup'), resourceId('Microsoft.Network/networkSecurityGroups', variables('newNsgName')), parameters('networkSecurityGroupId'))]",
         "isVMAdminAccountCredentialsProvided": "[and(not(equals(parameters('vmAdministratorAccountUsername'), '')), not(equals(parameters('vmAdministratorAccountPassword'), '')))]",
         "vmAdministratorUsername": "[if(variables('isVMAdminAccountCredentialsProvided'), parameters('vmAdministratorAccountUsername'), first(split(parameters('administratorAccountUsername'), '@')))]",
@@ -228,7 +229,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
+            "name": "[variables('newNsgDeploymentName')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -277,7 +278,7 @@
                 "networkSecurityGroup":"[if(empty(parameters('networkSecurityGroupId')), json('null'), json(concat('{\"id\": \"', variables('nsgId'), '\"}')))]"                     
             },
             "dependsOn": [
-                "NSG-linkedTemplate"
+                "[variables('newNsgDeploymentName')]"
             ]
         },
         {

--- a/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
+++ b/ARM-wvd-templates/nestedtemplates/unmanagedDisks-customvhdvm.json
@@ -228,7 +228,7 @@
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "NSG-linkedTemplate",
+            "name": "[concat('NSG-linkedTemplate-', parameters('_guidValue'))]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",


### PR DESCRIPTION
Fixes an issue where new deployments fail if the NSG-Linkedtemplate deployment is stuck in a deleting state or otherwise in use and can not be used as the deployment name for new deployments.