### PR TITLE
`ARM-wvd-templates`: Remove RD Connection Broker if installed on Windows Server

### DIFF
--- a/ARM-wvd-templates/DSC/Configuration.ps1
+++ b/ARM-wvd-templates/DSC/Configuration.ps1
@@ -51,7 +51,8 @@ configuration AddSessionHost
 
             Script ExecuteRdAgentInstallServer
             {
-                DependsOn = "[WindowsFeature]RDS-Connection-Broker"
+                DependsOn = "[WindowsFeature]RDS-RD-Server", "[WindowsFeature]RDS-Connection-Broker"
+
                 GetScript = {
                     return @{'Result' = ''}
                 }

--- a/ARM-wvd-templates/DSC/Configuration.ps1
+++ b/ARM-wvd-templates/DSC/Configuration.ps1
@@ -42,9 +42,16 @@ configuration AddSessionHost
                 Name = "RDS-RD-Server"
             }
 
+            # Ensure no RDS Connection Broker installed, otherwise the AVD sessions might be denied (`ConnectionDeniedByServer` error in RDInfra Agent logs)
+            WindowsFeature RDS-Connection-Broker
+            {
+                Ensure = "Absent"
+                Name = "RDS-Connection-Broker"
+            }
+
             Script ExecuteRdAgentInstallServer
             {
-                DependsOn = "[WindowsFeature]RDS-RD-Server"
+                DependsOn = "[WindowsFeature]RDS-Connection-Broker"
                 GetScript = {
                     return @{'Result' = ''}
                 }


### PR DESCRIPTION
The RD Connection broker might conflict with AVD logic and result in clients getting their access denied despite the configuration looks correct.

The issue manifests itself with the following events:

1.  `Microsoft-Windows-TerminalServices-SessionBroker-Client/Operational`:
   ```
    Remote Desktop Connection Broker Client failed while getting redirection packet from Connection Broker. 
    User : <...>
    Error: Remote Desktop Connection Broker is not ready for RPC communication. 
   ```

2. `Application and Service Logs/RemoteDesktopServices`:
   ```
   Connection failure: 7::777 17(ConnectionDeniedByServer),
   'The session host doesn't have Remote Desktop access or has a policy that blocks access.'; internal=False
    ...
   TriggerErrorEvent with Error: RDStack::ConnectionEstablished failed with code 17 and message
   The session host doesn't have Remote Desktop access or has a policy that blocks access.
   ```

