### PR TITLE
Fixing registration info bug

### DIFF
--- a/wvd-sh/terraform-azurerm-azuresvirtualdesktop/main.tf
+++ b/wvd-sh/terraform-azurerm-azuresvirtualdesktop/main.tf
@@ -35,6 +35,13 @@ resource "azurerm_virtual_desktop_host_pool" "hostpool" {
   }
 }
 
+# Create a resource for the registration token
+resource "azurerm_virtual_desktop_host_pool_registration_info" "registration_info" {
+  hostpool_id     = azurerm_virtual_desktop_host_pool.hostpool.id
+  # Expiration date must be within 30 days
+  expiration_date = "2022-03-03T23:40:52Z"
+}
+
 # Create AVD DAG
 resource "azurerm_virtual_desktop_application_group" "dag" {
   resource_group_name = azurerm_resource_group.rg.name


### PR DESCRIPTION
There is a bug with this operation in host.tf since terraform's registry.terraform.io/hashicorp/azurerm v2.92.0:  registration_token = azurerm_virtual_desktop_host_pool.hostpool.registration_info[0].token 

More background here: https://github.com/hashicorp/terraform-provider-azurerm/pull/14953

I tested on my side and this fixes the issue - if you don't update this, your entire code will fail because hosts won't be able to retrieve the registration token to join the host pool.

I'm also proposing a change in host.tf, please accept both, thank you