### PR TITLE
Fixing registration_info bug

### DIFF
--- a/wvd-sh/terraform-azurerm-azuresvirtualdesktop/host.tf
+++ b/wvd-sh/terraform-azurerm-azuresvirtualdesktop/host.tf
@@ -1,5 +1,5 @@
 locals {
-  registration_token = azurerm_virtual_desktop_host_pool.hostpool.registration_info[0].token
+  registration_token = azurerm_virtual_desktop_host_pool_registration_info.registration_info.token
 }
 
 resource "random_string" "AVD_local_password" {


### PR DESCRIPTION
There is a bug with this operation in host.tf since terraform's registry.terraform.io/hashicorp/azurerm v2.92.0: registration_token = azurerm_virtual_desktop_host_pool.hostpool.registration_info[0].token

More background here: hashicorp/terraform-provider-azurerm#14953

I tested on my side and this fixes the issue - if you don't update this, your entire code will fail because hosts won't be able to retrieve the registration token to join the host pool.

I'm also proposing a change in main.tf, please accept both, thank you