### PR TITLE
Handle RD Infra Agent and Bootloader install strings containing spaces gracefully

### DIFF
--- a/wvd-templates/DSC/Functions.ps1
+++ b/wvd-templates/DSC/Functions.ps1
@@ -473,10 +473,10 @@ function InstallRDAgents {
     }
 
     Write-Log -Message "Installing RD Infra Agent on VM $AgentInstaller"
-    RunMsiWithRetry -programDisplayName "RD Infra Agent" -argumentList @("/i $AgentInstaller", "/quiet", "/qn", "/norestart", "/passive", "REGISTRATIONTOKEN=$RegistrationToken") -msiOutputLogPath "C:\Users\AgentInstall.txt" -msiLogVerboseOutput:$EnableVerboseMsiLogging
+    RunMsiWithRetry -programDisplayName "RD Infra Agent" -argumentList @("/i '$AgentInstaller'", "/quiet", "/qn", "/norestart", "/passive", "REGISTRATIONTOKEN=$RegistrationToken") -msiOutputLogPath "C:\Users\AgentInstall.txt" -msiLogVerboseOutput:$EnableVerboseMsiLogging
 
     Write-Log -Message "Installing RDAgent BootLoader on VM $AgentBootServiceInstaller"
-    RunMsiWithRetry -programDisplayName "RDAgent BootLoader" -argumentList @("/i $AgentBootServiceInstaller", "/quiet", "/qn", "/norestart", "/passive") -msiOutputLogPath "C:\Users\AgentBootLoaderInstall.txt" -msiLogVerboseOutput:$EnableVerboseMsiLogging
+    RunMsiWithRetry -programDisplayName "RDAgent BootLoader" -argumentList @("/i '$AgentBootServiceInstaller'", "/quiet", "/qn", "/norestart", "/passive") -msiOutputLogPath "C:\Users\AgentBootLoaderInstall.txt" -msiLogVerboseOutput:$EnableVerboseMsiLogging
 
     $bootloaderServiceName = "RDAgentBootLoader"
     $startBootloaderRetryCount = 0


### PR DESCRIPTION
- When the RDAgentBootLoader name contains a space in the title (exp. Microsoft.RDInfra.RDAgentBootLoader.Installer-x64 (7).msi), it causes the DSC Installation to hang in a transitioning phase as the msiexec command can't recognize the install.
- Encapsulated all /i $Path strings so they look like /i '$Path'.