### PR TITLE
Set registry key required for AAD Join and AVD

### DIFF
--- a/ARM-wvd-templates/DSC/Script-SetupSessionHost.ps1
+++ b/ARM-wvd-templates/DSC/Script-SetupSessionHost.ps1
@@ -67,7 +67,18 @@ if (Test-path $rdInfraAgentRegistryPath) {
 }
 
 if ($AadJoin) {
-    # 6 Minute sleep to guarantee intune metadata logging
+    # Set Azure AD Join registry key
+    $KeyPath = "HKLM:\SOFTWARE\Microsoft\RDInfraAgent\AADJPrivate"
+
+    if (!(Get-Item -Path $KeyPath -ErrorAction SilentlyContinue)) {
+        Write-Log -Message ("Registry Key for AADJPrivate doesn't exist. Creating now...")
+        New-Item -Path $KeyPath -Force | Out-Null
+    }
+    else {
+        Write-Log -Message ("Registry Key for AADJPrivate exists.")
+    }
+
+    # 6 Minute sleep to guarantee Intune metadata logging
     Write-Log -Message ("Configuration.ps1 complete, sleeping for 6 minutes")
     Start-Sleep -Seconds 360
     Write-Log -Message ("Configuration.ps1 complete, waking up from 6 minute sleep")


### PR DESCRIPTION
Resolves the failing 'DomainJoinedCheck' health check for AVD.
1: https://docs.microsoft.com/en-us/answers/questions/489676/aad-joined-avd-sessionhost-is-not-joined-to-a-doma.html
2: https://stackoverflow.com/questions/70743129/terraform-azure-vm-extension-does-not-join-vm-to-azure-active-directory-for-azur