### PR TITLE
Update CreateOrUpdateAzAutoAccount.ps1

### DIFF
--- a/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
+++ b/wvd-templates/wvd-scaling-script/CreateOrUpdateAzAutoAccount.ps1
@@ -176,7 +176,7 @@ function Add-ModuleToAutoAccount {
 
 	# Check if the required modules are imported
 	$ImportedModule = Get-AzAutomationModule -ResourceGroupName $ResourceGroupName -AutomationAccountName $AutomationAccountName -Name $ModuleName -ErrorAction SilentlyContinue
-	if ($ImportedModule -and $ImportedModule.Version -ge $ModuleVersion) {
+	if ($ImportedModule -and  [version]$ImportedModule.Version -ge  [version]$ModuleVersion) {
 		return
 	}
 


### PR DESCRIPTION
Comparing Module Version as a string variable, This will get incorrect results. so this script will get error.
(Comparing "2.8.0" and "2.10.0" will assume that "2.8.0" is newer.)

Added casts to the comparison equation.