### PR TITLE
Remove trailing '-' in TemplateParameterFile flag

### DIFF
--- a/AzureFirewallPolicyForAVD/Deploy_PowerShell.ps1
+++ b/AzureFirewallPolicyForAVD/Deploy_PowerShell.ps1
@@ -6,7 +6,7 @@ $ResourceGroupName = "<<<Your Resource Group Name>>>"
 $Location = "<<<Your Azure Region>>>"
 
 # Run the deployment
-New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -Location $Location -TemplateFile ".\FirewallPolicyForAVD-template.json" -TemplateParameterFile ".\FirewallPolicyForAVD-parameters-.json"
+New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -Location $Location -TemplateFile ".\FirewallPolicyForAVD-template.json" -TemplateParameterFile ".\FirewallPolicyForAVD-parameters.json"
 
 # Once completed, review all the Policy settings and rules, then associate to an existing Firewall: #
 


### PR DESCRIPTION
There is a trailing dash used in the reference to FirewallPolicyForAVD-parameters.json that causes an error when executing the New-AzResourceGroupDeployment cmd on line 9.  Simply removing the '-' resolves the issue and ensures that once all the other variables are filled in it runs smoothly.