### PR TITLE
Update managedDisks-customimagevm.json to avoid loops depending on loops

### DIFF
--- a/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
+++ b/ARM-wvd-templates/nestedtemplates/managedDisks-customimagevm.json
@@ -498,7 +498,9 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '/', 'Microsoft.PowerShell.DSC')]",
       "location": "[parameters('location')]",
-      "dependsOn": [ "rdsh-vm-loop" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber'))))]"
+      ],
       "copy": {
         "name": "rdsh-dsc-loop",
         "count": "[parameters('rdshNumberOfInstances')]"
@@ -529,7 +531,9 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '/', 'AADLoginForWindows')]",
       "location": "[parameters('location')]",
-      "dependsOn": [ "rdsh-dsc-loop" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber'))), 'Microsoft.PowerShell.DSC')]"
+      ],
       "copy": {
         "name": "rdsh-aad-join-loop",
         "count": "[parameters('rdshNumberOfInstances')]"
@@ -548,7 +552,9 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')), '/', 'joindomain')]",
       "location": "[parameters('location')]",
-      "dependsOn": [ "rdsh-dsc-loop" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber'))), 'Microsoft.PowerShell.DSC')]"
+      ],
       "copy": {
         "name": "rdsh-domain-join-loop",
         "count": "[parameters('rdshNumberOfInstances')]"


### PR DESCRIPTION
The Deployment Engine processes each resource in a loop as if it depended on **every** resource in the previous loop iteration. This information is exposed on a deployment GET request via `properties.dependencies`, which contains a lot of data. The amount of data returned by this request is proportional to `loop_size^2` as a result of this authoring pattern, which can result in huge amounts of data and slow performance for users with large loop counts.