### PR TITLE
Typo fixes and region dropdowns

### DIFF
--- a/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
+++ b/ARM-wvd-templates/CreateAndProvisionHostPool/CreateHostpoolTemplate.json
@@ -109,10 +109,10 @@
           "description": "The location where the resources will be deployed."
         }
       },
-      "workSpaceName": {
+      "workspaceName": {
         "type": "string",
         "metadata": {
-          "description": "The name of the workspace to be attach to new Applicaiton Group."
+          "description": "The name of the workspace to be attach to new Application Group."
         },
         "defaultValue": ""
       },
@@ -778,7 +778,7 @@
             "resources": [
               {
                 "apiVersion": "[parameters('apiVersion')]",
-                "name": "[parameters('workSpaceName')]",
+                "name": "[parameters('workspaceName')]",
                 "type": "Microsoft.DesktopVirtualization/workspaces",
                 "location": "[parameters('workspaceLocation')]",
                 "properties": {
@@ -1024,7 +1024,7 @@
         "apiVersion": "2017-05-01-preview",
         "condition": "[and(parameters('isNewWorkspace'),or(variables('sendLogsToEventHub'),variables('sendLogsToLogAnalytics'), variables('sendLogsToStorageAccount')))]",
         "location": "[parameters('location')]",
-        "name": "[concat(if(parameters('isNewWorkspace'), parameters('workSpaceName'), 'placeholder'), '/Microsoft.Insights/', 'diagnosticSetting')]",
+        "name": "[concat(if(parameters('isNewWorkspace'), parameters('workspaceName'), 'placeholder'), '/Microsoft.Insights/', 'diagnosticSetting')]",
         "properties": {
           "storageAccountId": "[if(variables('sendLogsToStorageAccount'), variables('storageAccountIdProperty'), null())]",
           "eventHubAuthorizationRuleId": "[if(variables('sendLogsToEventHub'), parameters('hostpoolDiagnosticSettingsEventHubAuthorizationId'), null())]",

--- a/ARM-wvd-templates/HCI/CreateHciHostpoolTemplate.json
+++ b/ARM-wvd-templates/HCI/CreateHciHostpoolTemplate.json
@@ -24,6 +24,10 @@
       },
       "location": {
         "type": "string",
+        "allowedValues": [
+          "eastus",
+          "westeurope"
+        ],
         "metadata": {
           "description": "Enter a region where Hostpool, workspace, virtual machines will be created. The metadata for these objects will be stored in the geography associated with the region. Supported regions: eastus and westeurope."
         }
@@ -76,10 +80,10 @@
         },
         "defaultValue": 0
       },
-      "workSpaceName": {
+      "workspaceName": {
         "type": "string",
         "metadata": {
-          "description": "The name of the workspace to be attach to new Applicaiton Group."
+          "description": "The name of the workspace to be attach to new Application Group."
         },
         "defaultValue": ""
       },
@@ -381,7 +385,7 @@
             "resources": [
               {
                 "apiVersion": "2019-12-10-preview",
-                "name": "[parameters('workSpaceName')]",
+                "name": "[parameters('workspaceName')]",
                 "type": "Microsoft.DesktopVirtualization/workspaces",
                 "location": "[parameters('workspaceLocation')]",
                 "properties": {

--- a/ARM-wvd-templates/HCI/HybridCompute/CreateHciHostpoolHybridComputeTemplate.json
+++ b/ARM-wvd-templates/HCI/HybridCompute/CreateHciHostpoolHybridComputeTemplate.json
@@ -10,7 +10,11 @@
     },
     "location": {
       "type": "string",
-      "metadata": {
+      "allowedValues": [
+        "eastus",
+        "westeurope"
+      ],
+    "metadata": {
         "description": "Enter a region where Host pool, workspace, application group will be created. The metadata for these objects will be stored in the geography associated with the region. Supported regions: eastus and westeurope."
       }
     },

--- a/ARM-wvd-templates/HCI/QuickDeploy/CreateHciHostpoolQuickDeployTemplate.json
+++ b/ARM-wvd-templates/HCI/QuickDeploy/CreateHciHostpoolQuickDeployTemplate.json
@@ -9,6 +9,10 @@
         }
       },
       "location": {
+        "allowedValues": [
+          "eastus",
+          "westeurope"
+        ],
         "type": "string",
         "metadata": {
           "description": "Enter a region where Hostpool, workspace, virtual machines will be created. The metadata for these objects will be stored in the geography associated with the region. Supported regions: eastus and westeurope."
@@ -17,7 +21,7 @@
       "customLocationId": {
         "type": "string",
         "metadata": {
-          "description": "A deployment target created and customized by your organization for creating virtual machines. The custom location is associated to an Azure Stack HCI cluster. E.g., /subscriptions/<subscriptionID>/resourcegroups/Contoso-rg/providers/microsoft.extendedlocation/customlocations/Contoso-CL"
+         "description": "A deployment target created and customized by your organization for creating virtual machines. The custom location is associated to an Azure Stack HCI cluster. E.g., /subscriptions/<subscriptionID>/resourcegroups/Contoso-rg/providers/microsoft.extendedlocation/customlocations/Contoso-CL"
         }
       },
       "virtualProcessorCount": {
@@ -37,7 +41,7 @@
       "workspaceName": {
         "type": "string",
         "metadata": {
-          "description": "The name of the workspace to be attach to new Applicaiton Group."
+          "description": "The name of the workspace to be attach to new Application Group."
         }
       },
       "vmAdministratorAccountUsername": {


### PR DESCRIPTION
Multiple fixes:

- "Application" instead of "Applicaiton"
- "workspace" instead of "workSpace" (consistency and UI issue)
- allowed values for metadata region to make a dropdown