### PR TITLE
added provisionVMConfigAgent flag in os profile of arcvm template

### DIFF
--- a/ARM-wvd-templates/nestedtemplates/azurestackhci-vm.json
+++ b/ARM-wvd-templates/nestedtemplates/azurestackhci-vm.json
@@ -274,7 +274,8 @@
                   "adminUsername": "[variables('vmAdministratorUsername')]",
                   "adminPassword": "[variables('vmAdministratorPassword')]",
                   "windowsConfiguration": {
-                      "provisionVMAgent": true
+                      "provisionVMAgent": true,
+                      "provisionVMConfigAgent": true
                   },
                   "computerName": "[concat(parameters('rdshPrefix'), add(copyindex(), parameters('vmInitialNumber')))]"
               },


### PR DESCRIPTION
added provisionVMConfigAgent flag in os profile of arcvm template. This will enable the v2 version of guest management provisioning (using hyper v sockets) to reduce customer issues while we continue to use api version 2023-09-01-preview