### PR TITLE
Updated Microsoft.Resources/deployments API Version 2019-05-01

### DIFF
--- a/ARM-wvd-templates/HCI/QuickDeploy/AddHciVirtualMachinesQuickDeployTemplate.json
+++ b/ARM-wvd-templates/HCI/QuickDeploy/AddHciVirtualMachinesQuickDeployTemplate.json
@@ -176,7 +176,7 @@
     },
     "resources": [
       {
-        "apiVersion": "2018-05-01",
+        "apiVersion": "2019-05-01",
         "name": "[concat('UpdateHostPool-', parameters('deploymentId'))]",
         "type": "Microsoft.Resources/deployments",
         "resourceGroup": "[parameters('hostpoolResourceGroup')]",
@@ -199,7 +199,7 @@
         }
       },
       {
-        "apiVersion": "2018-05-01",
+        "apiVersion": "2019-05-01",
         "name": "[concat('hci-addVms-linkedTemplate-', parameters('deploymentId'))]",
         "type": "Microsoft.Resources/deployments",
         "resourceGroup": "[parameters('vmResourceGroup')]",


### PR DESCRIPTION
Leaving as 2018-05-01 results in error: Deployment template validation failed: 'The template resource 'default' at line '295' and column '153' is invalid. The api-version '2018-05-01' used to deploy the template does not support 'Scope' property. Please use api-version '2019-05-01' or later to deploy the template.