### PR TITLE
Change Set-RegKey function to start of script

### DIFF
--- a/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/DisableStorageSense.ps1
+++ b/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/DisableStorageSense.ps1
@@ -6,6 +6,16 @@
 #    Disable Storage Sense            #
 #######################################
 
+function Set-RegKey($registryPath, $registryKey, $registryValue) {
+    try {
+         Write-Host "*** AVD AIB CUSTOMIZER PHASE ***  Disable Storage Sense - Setting  $registryKey with value $registryValue ***"
+         New-ItemProperty -Path $registryPath -Name $registryKey -Value $registryValue -PropertyType DWORD -Force -ErrorAction Stop
+    }
+    catch {
+         Write-Host "*** AVD AIB CUSTOMIZER PHASE ***   Disable Storage Sense  - Cannot add the registry key  $registryKey *** : [$($_.Exception.Message)]"
+    }
+ }
+
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 Write-Host "***Starting AVD AIB CUSTOMIZER PHASE: Disable Storage Sense Start -  $((Get-Date).ToUniversalTime()) "
 


### PR DESCRIPTION
Change Set-RegKey function to start of script for fix error "The term 'Set-RegKey' is not recognized as the name of a cmdlet, function, script file, or operable"