### PR TITLE
Set default Language and Region for all users

### DIFF
--- a/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
+++ b/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
@@ -165,6 +165,7 @@ try {
 
   if($null -ne $GeoID) {
     Set-WinHomeLocation -GeoID $GeoID
+    Copy-UserInternationalSettingsToSystem -WelcomeScreen $True -NewUser $True -Verbose -ErrorAction Stop
     Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - $Language with $LanguageTag has been set as the default region***"
   }
 } 


### PR DESCRIPTION
Sets the default Language and Region for all users by utilising Copy-UserInternationalSettingsToSystem.