### PR TITLE
Added STUN/TURN network rules to the Azure Firewall Policy

### DIFF
--- a/AzureFirewallPolicyForAVD/FirewallPolicyForAVD-template.json
+++ b/AzureFirewallPolicyForAVD/FirewallPolicyForAVD-template.json
@@ -372,6 +372,57 @@
                                 "destinationPorts": [
                                     "443"
                                 ]
+                            },
+                            {
+                                "ruleType": "NetworkRule",
+                                "name": "RDP Shortpath Server Endpoint",
+                                "ipProtocols": [
+                                    "UDP"
+                                ],
+                                "sourceAddresses": [
+                                    "[parameters('avd-hostpool-subnet')]"
+                                ],
+                                "sourceIpGroups": [],
+                                "destinationAddresses": ["*"],
+                                "destinationIpGroups": [],
+                                "destinationFqdns": [],
+                                "destinationPorts": [
+                                    "49152-65535"
+                                ]
+                            },
+                            {
+                                "ruleType": "NetworkRule",
+                                "name": "STUN/TURN UDP",
+                                "ipProtocols": [
+                                    "UDP"
+                                ],
+                                "sourceAddresses": [
+                                    "[parameters('avd-hostpool-subnet')]"
+                                ],
+                                "sourceIpGroups": [],
+                                "destinationAddresses": ["20.202.0.0/16"],
+                                "destinationIpGroups": [],
+                                "destinationFqdns": [],
+                                "destinationPorts": [
+                                    "3478"
+                                ]
+                            },
+                            {
+                                "ruleType": "NetworkRule",
+                                "name": "STUN/TURN TCP",
+                                "ipProtocols": [
+                                    "TCP"
+                                ],
+                                "sourceAddresses": [
+                                    "[parameters('avd-hostpool-subnet')]"
+                                ],
+                                "sourceIpGroups": [],
+                                "destinationAddresses": ["20.202.0.0/16"],
+                                "destinationIpGroups": [],
+                                "destinationFqdns": [],
+                                "destinationPorts": [
+                                    "443"
+                                ]
                             }
                         ],
                         "name": "NetworkRules_AVD-Optional",


### PR DESCRIPTION
Added rules to support RDP Shortpath 

![image](https://github.com/user-attachments/assets/4fbd1a95-9363-4767-89dd-41c3b5b9982b)

ref. https://learn.microsoft.com/en-us/azure/virtual-desktop/rdp-shortpath?tabs=public-networks#session-host-virtual-network
