### PR TITLE
Using VHD Location instead of CCD location 

### DIFF
--- a/Scripts/CustomImageTemplateScripts/FSLogix.ps1
+++ b/Scripts/CustomImageTemplateScripts/FSLogix.ps1
@@ -103,8 +103,8 @@ Set-ItemProperty `
 New-ItemProperty `
     -Path HKLM:\Software\FSLogix\Profiles `
     -Name "VHDLocations" `
-    -Value "type=smb,connectionString=$ProfilePath" `
-    -PropertyType MultiString `
+    -Value "$ProfilePath" `
+    -PropertyType String `
     -Force
 Set-ItemProperty `
     -Path HKLM:\Software\FSLogix\Profiles `


### PR DESCRIPTION
Using VHD Locations instead of CCD Location as Cloud Cache as cloud cache consumes additional IOPS 