### PR TITLE
Update Migrate-MsixPackagesToAppAttach.ps1

### DIFF
--- a/msix-app-attach/MigrationScript/Migrate-MsixPackagesToAppAttach.ps1
+++ b/msix-app-attach/MigrationScript/Migrate-MsixPackagesToAppAttach.ps1
@@ -554,11 +554,9 @@ process {
 
                 if ($roleAssignment.ObjectType -eq "User") {
                     $roleAssignment.SignInName
-                    Write-Log ("Granting user " + $roleAssignment.SignInName + "access to package $MsixName")
                 }
                 if ($roleAssignment.ObjectType -eq "Group") {
                     $roleAssignment.DisplayName
-                    Write-Log ("Granting group " + $roleAssignment.DisplayName + "access to package $MsixName")
                 }
 
             }
@@ -616,7 +614,8 @@ process {
     foreach ($item in $permissionsToAdd) {
         try {
             # check if it is an email address
-            if ($item -match $emailRegex) {
+            if ($item -like "*@*") {
+                Write-Log ("Granting user " + $item + "access to package $MsixName")
                 $role = Get-AzRoleAssignment -SignInName $item -RoleDefinitionName "Desktop Virtualization User" -Scope $appAttachPackage.Id
                 if ($null -eq $role) {
                     $null = New-AzRoleAssignment -SignInName $item -RoleDefinitionName "Desktop Virtualization User" -Scope $appAttachPackage.Id
@@ -636,6 +635,7 @@ process {
                         while ($retryCount -lt $retryMax -and (Get-Date) -lt $maximalWait) {
                             try {
                                 $retryCount++
+                                Write-Log ("Granting group " + $item + "access to package $MsixName")
                                 $role = Get-AzRoleAssignment -ObjectId $group.Id -RoleDefinitionName "Desktop Virtualization User" -Scope $appAttachPackage.Id
                                 if ($null -eq $role) {
                                     $null = New-AzRoleAssignment -ObjectId $group.Id -RoleDefinitionName "Desktop Virtualization User" -Scope $appAttachPackage.Id
@@ -707,7 +707,7 @@ process {
     }
     if ($setActiveAfterCreate) {
         try { 
-            Update-AzWvdAppAttachPackage -SubscriptionId $SubscriptionId -ResourceGroupName $newResourceGroup -Name $MsixName -IsActive -Location $newLocation -ErrorAction Stop
+            Update-AzWvdAppAttachPackage -SubscriptionId $SubscriptionId -ResourceGroupName $newResourceGroup -Name $MsixName -IsActive -ErrorAction Stop
             Write-Log "Package $MsixName activated"
         }
         catch {


### PR DESCRIPTION
The Script was failing at "Permissions" for Groups and "Location" parameter. I removed the Location Parameter under Line # 710 which is not required for "SetActiveAfterCreate"

To resolve Group assignment issue, I removed "-match $emailRegex" and add "-like "*@*"".

This resolved both  issue and made this script migrating MSIX packages from MSIX App attach to App Attach Successfully.

I hope this helps to everyone!