### PR TITLE
Corrected registry hive format

### DIFF
--- a/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/DisableAutoUpdates.ps1
+++ b/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/DisableAutoUpdates.ps1
@@ -23,9 +23,9 @@ function Set-RegKey($registryPath, $registryKey, $registryValue) {
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 Write-Host "***Starting AVD AIB CUSTOMIZER PHASE: Disable auto updates for MSIX AA applications -  $((Get-Date).ToUniversalTime()) "
 
-Set-RegKey -registryPath "HKLM\Software\Policies\Microsoft\WindowsStore" -registryKey "AutoDownload" -registryValue "2"
-Set-RegKey -registryPath "HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -registryKey "PreInstalledAppsEnabled" -registryValue "0"
-Set-RegKey -registryPath "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager\Debug" -registryKey "ContentDeliveryAllowedOverride" -registryValue "0x2"
+Set-RegKey -registryPath "HKLM:\Software\Policies\Microsoft\WindowsStore" -registryKey "AutoDownload" -registryValue "2"
+Set-RegKey -registryPath "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -registryKey "PreInstalledAppsEnabled" -registryValue "0"
+Set-RegKey -registryPath "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager\Debug" -registryKey "ContentDeliveryAllowedOverride" -registryValue "0x2"
 
 Disable-ScheduledTask -TaskPath "\Microsoft\Windows\WindowsUpdate\" -TaskName "Scheduled Start"
 


### PR DESCRIPTION
I noticed the DisableAutoUpdates.ps1 script from AVD custom image templates wasn't working. When I reviewed the code, the registry paths were missing the colon, so the script treated them as paths rather than registry hives.


<img width="3262" height="1064" alt="image" src="https://github.com/user-attachments/assets/bb25b5e0-e926-465a-b8ba-044fbaf0b022" />
