### PR TITLE
Corrected registry hive format

### DIFF
--- a/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
+++ b/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
@@ -76,7 +76,7 @@ function UpdateRegionSettings($GeoID)
     }
 
     #Set Region in Default User Profile (applies to all new users)
-    New-ItemProperty -Path "HKU\.DEFAULT\Control Panel\International\Geo" -Name "Nation" -Value $GeoID -PropertyType String -Force
+    New-ItemProperty -Path "Registry::HKEY_USERS\.DEFAULT\Control Panel\International\Geo" -Name "Nation" -Value $GeoID -PropertyType String -Force
     Set-WinHomeLocation -GeoId $GeoID
     Write-Host "***Starting AVD AIB CUSTOMIZER PHASE: Set default Language - Region update completed."
   }


### PR DESCRIPTION
I noticed the SetDefaultLang.ps1 script from AVD custom image templates wasn't working. When I reviewed the code, the registry path was formatted incorrectly, so the script treated them as paths rather than registry hives.

<img width="2284" height="539" alt="image" src="https://github.com/user-attachments/assets/1615b93a-43a1-4081-8ca4-b19382243dd6" />
