### PR TITLE
Fix an error occurs in setDefaultLanguage.ps1 during the creation of an AVD custom image template

### DIFF
--- a/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
+++ b/CustomImageTemplateScripts/CustomImageTemplateScripts_2024-03-27/SetDefaultLang.ps1
@@ -135,11 +135,10 @@ $LanguagesDictionary.Add("Ukrainian (Ukraine)",	"uk-UA")
 $LanguagesDictionary.Add("English (Australia)",	"en-AU")
 
 try {
-  # Disable LanguageComponentsInstaller while installing language packs
-  # See Bug 45044965: Installing language pack fails with error: ERROR_SHARING_VIOLATION for more details
-  Disable-ScheduledTask -TaskName "\Microsoft\Windows\LanguageComponentsInstaller\Installation"
-  Disable-ScheduledTask -TaskName "\Microsoft\Windows\LanguageComponentsInstaller\ReconcileLanguageResources"
+  $osBuild = [System.Environment]::OSVersion.Version.Build
+  Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - OS Build: $osBuild ***"
 
+  # Resolve language tag early so we can use it in the reconcile wait below.
   $languageDetails = Get-RegionInfo -Name $Language
 
   if($null -eq $languageDetails) {
@@ -148,6 +147,55 @@ try {
     $languageTag = $languageDetails[0]
     $GeoID = $languageDetails[1]
   }
+
+  # On Win11 23H2 (Build 22631), Install-Language no longer delivers LpCab synchronously.
+  # The LanguagePack is delivered asynchronously by ReconcileLanguageResources, which starts
+  # running during the WU+Restart window between InstallLanguagePacks and SetDefaultLang.
+  # Wait for reconcile to finish delivering LpCab before disabling the tasks.
+  # See https://portal.microsofticm.com/imp/v5/incidents/details/805982457/summary.
+  if ($osBuild -eq 22631) {
+    # Only wait if the language was already installed by InstallLanguagePacks.ps1 (typical CIT flow).
+    # If language is not installed yet, skip the wait -- Install-Language below will handle it.
+    $preCheck = $null
+    try { $preCheck = Get-InstalledLanguage | Where-Object { $_.LanguageId -eq $LanguageTag } } catch {}
+
+    if ($preCheck) {
+      Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - 23H2 detected, waiting for $LanguageTag LanguagePack reconciliation ***"
+      $maxWaitSeconds = 600  # 10 minutes
+      $waited = 0
+      $lpReady = $false
+      while ($waited -lt $maxWaitSeconds) {
+          try {
+              $lpCheck = Get-InstalledLanguage | Where-Object { $_.LanguageId -eq $LanguageTag }
+              $lpPacksValue = "$($lpCheck.LanguagePacks)"
+              Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - LanguagePacks value: [$lpPacksValue] ***"
+              if ($lpPacksValue -and $lpPacksValue -ne "" -and $lpPacksValue -ne "None") {
+                  $lpReady = $true
+                  Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - LanguagePack ready for $LanguageTag (waited ${waited}s) ***"
+                  break
+              }
+          }
+          catch {
+              # If Get-InstalledLanguage fails, skip the wait
+              $lpReady = $true
+              break
+          }
+          Start-Sleep -Seconds 15
+          $waited += 15
+          Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - Waiting for reconcile... (${waited}s / ${maxWaitSeconds}s) ***"
+      }
+      if (-not $lpReady) {
+          Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - WARNING: LanguagePack not delivered after ${maxWaitSeconds}s, proceeding anyway ***"
+      }
+    } else {
+      Write-Host "*** AVD AIB CUSTOMIZER PHASE: Set default Language - 23H2 detected but $LanguageTag not yet installed, skipping reconcile wait ***"
+    }
+  }
+
+  # Disable LanguageComponentsInstaller while installing language packs
+  # See Bug 45044965: Installing language pack fails with error: ERROR_SHARING_VIOLATION for more details
+  Disable-ScheduledTask -TaskName "\Microsoft\Windows\LanguageComponentsInstaller\Installation" -ErrorAction SilentlyContinue
+  Disable-ScheduledTask -TaskName "\Microsoft\Windows\LanguageComponentsInstaller\ReconcileLanguageResources" -ErrorAction SilentlyContinue
 
   $foundLanguage = $false;
 
@@ -186,7 +234,7 @@ try {
   else {
      Write-Host "*** AVD AIB CUSTOMIZER PHASE : Set default language - Language pack for $LanguageTag is installed already***"
   }
-  
+
   Set-systempreferreduilanguage -Language $LanguageTag
   Set-WinSystemLocale -SystemLocale $LanguageTag
   Set-Culture -CultureInfo $LanguageTag


### PR DESCRIPTION
### Summary

Added a polling wait **before** `Disable-ScheduledTask` in `SetDefaultLang.ps1`, only on Build 22631 (Win11 23H2), only when the language was already installed by `InstallLanguagePacks.ps1`. This allows the `ReconcileLanguageResources` task (triggered by the WU+Restart between InstallLanguagePacks and SetDefaultLang) to finish delivering LpCab before the script disables it.

### Flow comparison

```
                    BEFORE FIX (race condition)

InstallLanguagePacks.ps1          SetDefaultLang.ps1
========================          ==================

Disable tasks                     Disable tasks    <-- kills reconcile!
Install-Language ja-JP            "already installed" (skip)
  -> LanguagePacks: None          Set-systempreferreduilanguage
Enable tasks                        -> FAILS! (LpCab not ready)
                                  Enable tasks
        |
   WU + Restart
   (reconcile starts here,
    may or may not finish
    before SetDefaultLang)
```

```
                    AFTER FIX (deterministic)

InstallLanguagePacks.ps1          SetDefaultLang.ps1
========================          ==================

Disable tasks                     [23H2 only] Poll Get-InstalledLanguage
Install-Language ja-JP              until LanguagePacks != None
  -> LanguagePacks: None            (max 600s, 15s interval)
Enable tasks                      Disable tasks    <-- safe, reconcile done
                                  "already installed" (skip)
        |                         Set-systempreferreduilanguage
   WU + Restart                     -> SUCCESS (LpCab ready)
   (reconcile runs here)          Enable tasks
```

```
Timeline:

InstallLanguagePacks.ps1                    SetDefaultLang.ps1
    |                                           |
    |  Disable tasks                            |
    |  Install-Language (LanguagePacks=None)     |
    |  Enable tasks                             |
    |                                           |
    +------ WU + Restart ---------------------->|
    |       ^                                   |
    |       | reconcile task starts here        |
    |       | (triggered by restart)            |
    |       |                                   |
    |       | downloading LpCab...              | [NEW] Check: is LanguagePacks
    |       | downloading LpCab...              |        still "None"?
    |       | LpCab ready!                      |        YES -> wait 15s, retry
    |       v                                   |        ...
    |                                           |        YES -> wait 15s, retry
    |                                           |        NO  -> LpCab ready!
    |                                           |
    |                                           | Disable tasks (safe now)
    |                                           | "already installed" branch
    |                                           | Set-systempreferreduilanguage -> OK
    |                                           | Copy-UserInternationalSettings -> OK
    |                                           | Enable tasks
    |                                           |
```

### Scope of change

- **Only affects Win11 23H2 (Build 22631)** -- all other OS versions skip the new code entirely
- **Only polls when language was already installed** by `InstallLanguagePacks.ps1` -- if language is not installed, skips the wait
- **Read-only polling** -- uses `Get-InstalledLanguage` (no side effects)
- **Max wait 600s (10 min)** -- if reconcile doesn't finish, proceeds anyway with a WARNING log
- **Zero impact on successful builds** -- if reconcile already finished during WU+Restart, first poll returns ready, 0s added