### PR TITLE
Replace plaintext ClientSecret with placeholder in diagnostics-sample appsettings.json

### DIFF
--- a/wvd-templates/diagnostics-sample/src/MSFT.WVD.Diagnostics/appsettings.json
+++ b/wvd-templates/diagnostics-sample/src/MSFT.WVD.Diagnostics/appsettings.json
@@ -5,7 +5,7 @@
     "TenantId": "common", //organizations
     "ClientId": "4139c5e6-4233-481a-9664-0acbf0093d3c",
     "LogAnalyticsWorkspaceId": "ee45406f-109e-48c1-bbd4-afbbf74e69d8", //"6fb37e86-270f-4c57-becb-85ec0211f3ce",
-    "ClientSecret": "nsSNwTbd/vwuN74ypE/DEDYdQqX8nPrQmZYFrY6s7vg="
+    "ClientSecret": "{ClientSecret}"
   },
   "configurations": {
     "RESOURCE_URL": "https://mrs-prod.ame.gbl/mrs-RDInfra-prod",


### PR DESCRIPTION
### What
Replace the hardcoded plaintext ClientSecret value in `wvd-templates/diagnostics-sample/src/MSFT.WVD.Diagnostics/appsettings.json` with a `{ClientSecret}` placeholder.

### Why
The file committed a real client secret in plaintext. The secret has already been revoked/rotated. This change prevents the plaintext value from appearing in the default branch and aligns it with the parameter-style placeholder convention.

### Notes
Only line 8 (`ClientSecret`) is changed; other values are left as-is.